### PR TITLE
Build Using Docker Container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
-language: cpp
+sudo: required
 
-compiler:
-  - clang
-  - gcc
+# blocklist
+branches:
+  except:
+  - master
+
+# safelist
+branches:
+  only:
+  - ci
 
 notifications:
   email:
     on_success: never # default: change
     on_failure: change # default: always
 
+services:
+  - docker
+
 before_install:
-  - sudo apt-get update --quiet
+- docker pull dranoel/cbs-devel
 
 script:
-  - cat /etc/*-releases
+# - ls -al ${PWD}
+- docker run --rm --workdir=/workspace --volume ${PWD}:/workspace dranoel/cbs-devel:latest ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+notifications:
+  email:
+    on_success: never # default: change
+    on_failure: change # default: always
+
+before_install:
+  - sudo apt-get update --quiet
+
+script:
+  - cat /etc/*-releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: required
 # blocklist
 branches:
   except:
-  - master
+  - ci
 
 # safelist
 branches:
   only:
-  - ci
+  - master
 
 notifications:
   email:

--- a/Build/build.cake
+++ b/Build/build.cake
@@ -36,18 +36,9 @@ Task("Build")
     .IsDependentOn("Restore-NuGet-Packages")
     .Does(() =>
 {
-    if(IsRunningOnWindows())
-    {
-      // Use MSBuild
-      MSBuild(slnFile, settings =>
-        settings.SetConfiguration(configuration));
-    }
-    else
-    {
-      // Use XBuild
-      XBuild(slnFile, settings =>
-        settings.SetConfiguration(configuration));
-    }
+    // Use MSBuild
+    MSBuild(slnFile, settings =>
+    settings.SetConfiguration(configuration));
 });
 
 Task("Run-Unit-Tests")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM microsoft/dotnet:latest
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install --yes \
+  curl \
+  gnupg \
+  && apt-key adv \
+  --keyserver hkp://keyserver.ubuntu.com:80 \
+  --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+RUN echo "deb http://download.mono-project.com/repo/debian stretch main" \
+  | tee /etc/apt/sources.list.d/mono-official.list
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install --yes \
+  mono-devel
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /tmp/* \
+  && rm -rf /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The folowing steps has to be done by a person with access to to CBS`s appveyor a
 Done by a developer
 1. Create the entry for the new bonding context in the `Build status` table on to of this page.
 
+### Build Using Docker Container
+
+* Build image: `./dockerize.sh`
+* Run container: `./containerize.sh`
+* Build example (inside container): `./build.sh`
 
 ## Contributing
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -x
+
+export DEBIAN_FRONTEND=noninteractive
+export WORKSPACE_DIR=/workspace
+export BUILD_DIR=${WORKSPACE_DIR}/Build
+
+if [ "$PWD" != "$WORKSPACE_DIR" ]; then
+  # Control will enter here if $DIRECTORY doesn't exists.
+  echo "Go to /workspace directory before running this script."
+  exit 1
+fi
+
+cd $BUILD_DIR
+# curl -Lsfo build.sh \
+#   https://cakebuild.net/download/bootstrapper/linux \
+#   && chmod +x build.sh \
+#   && ${PWD}/build.sh
+${PWD}/build.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,76 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: dranoel/cbs-devel:latest
+    working_directory: /workspace
+    steps:
+      - checkout
+      - run:
+          name: Interpolating Environment Variables to Set Other Environment Variables
+          # If you need to interpolate other environment variables to set an environment variable, the only place to do this at the moment is in bash.
+          # CircleCI 2.0 automatically sets a $BASH_ENV variable to a random name in /tmp, and will source this file for each step.
+          # https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables
+          command: |
+            echo 'export DEBIAN_FRONTEND=noninteractive' >> $BASH_ENV
+            echo 'export WORKSPACE_DIR=/workspace' >> $BASH_ENV
+      - run:
+          name: Version
+          command: |
+            set -x
+            cat /etc/*release
+      - run:
+          name: Build
+          command: |
+            set -x
+            cd ${WORKSPACE_DIR}
+            bash ${PWD}/build.sh
+      - store_artifacts:
+          path: Source/Infrastructure/Application/bin/Release/netstandard2.0/
+      # - store_artifacts:
+      #     path: Source/Infrastructure/AspNet/bin/Release/netstandard2.0/
+  test:
+    docker:
+      - image: dranoel/cbs-devel:latest
+    working_directory: /workspace
+    steps:
+      - checkout
+      - run:
+          name: Interpolating Environment Variables to Set Other Environment Variables
+          # If you need to interpolate other environment variables to set an environment variable, the only place to do this at the moment is in bash.
+          # CircleCI 2.0 automatically sets a $BASH_ENV variable to a random name in /tmp, and will source this file for each step.
+          # https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables
+          command: |
+            echo 'export DEBIAN_FRONTEND=noninteractive' >> $BASH_ENV
+            echo 'export WORKSPACE_DIR=/workspace' >> $BASH_ENV
+      - run:
+          name: Check Version
+          command: |
+            set -x
+            cat /etc/*release
+      - run:
+          name: Build
+          command: |
+            set -x
+            cd ${WORKSPACE_DIR}
+            bash ${PWD}/build.sh
+      - store_artifacts:
+          path: Source/Infrastructure/Application/bin/Release/netstandard2.0/
+          destination: infrastructure-application-bin-release-netstandard2
+      # - store_artifacts:
+      #     path: Source/Infrastructure/AspNet/bin/Release/netstandard2.0/
+      #     destination: infrastructure-AspNet-bin-release-netstandard2
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: ci
+      - test:
+          requires:
+            - build
+          filters:
+            branches:
+              only: ci

--- a/circle.yml
+++ b/circle.yml
@@ -67,10 +67,10 @@ workflows:
       - build:
           filters:
             branches:
-              only: ci
+              only: master
       - test:
           requires:
             - build
           filters:
             branches:
-              only: ci
+              only: master

--- a/containerize.sh
+++ b/containerize.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# git clean -dfx && git submodule foreach "git clean -dfx"
+# git submodule update --init
+
+docker run --rm --tty --interactive --workdir=/workspace --volume ${PWD}:/workspace dranoel/cbs-devel:latest bash

--- a/dockerize.sh
+++ b/dockerize.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build --tag dranoel/cbs-devel:latest --file ${PWD}/Dockerfile ${PWD}


### PR DESCRIPTION
### Build Using Docker Container

* Build image: `./dockerize.sh`
* Run container: `./containerize.sh`
* Build example (inside container): `./build.sh`

Initial setup for both TravisCI and CircleCI are included.

ToDo: Host the Docker image with proper naming instead of using a personal account.