### PR TITLE
Move build status for all projects into the main readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Build status
 | Project  | AppVeyor Status  |
 |---|---|
-| Example  | [![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/somthing)  |
+| Example  | [![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs-c5ssa)  |
 | VolunteerReporting  | [![Build status](https://ci.appveyor.com/api/projects/status/o77909lns7ubfxdl?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs/build/1.1.0-30-nsotvffx)  |
 
 ## Setup Ci build for as new bounding context

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Build status
 | Project  | AppVeyor Status  |
 |---|---|
-| Example  | [![Build status](https://ci.appveyor.com/api/projects/status/aymmq31lpjdsxk6v?svg=true)](https://ci.appveyor.com/project/karolikl/cbs)  |
+| Example  | [![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/somthing)  |
+| VolunteerReporting  | [![Build status](https://ci.appveyor.com/api/projects/status/o77909lns7ubfxdl?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs/build/1.1.0-30-nsotvffx)  |
 
 ## Setup Ci build for as new bounding context
 1. Copy the `appveyor.yml` file from (Build/appveyor.yml) into the root source folder for the bounding context.

--- a/Source/Example/readme.md
+++ b/Source/Example/readme.md
@@ -1,7 +1,7 @@
 # CBS Example backend application
 
 ## Build status
-[![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/somthing)
+[![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs-c5ssa)
 
 ## Prerequisites
 

--- a/Source/Example/readme.md
+++ b/Source/Example/readme.md
@@ -1,11 +1,7 @@
 # CBS Example backend application
 
 ## Build status
-| Project  | AppVeyor Status  |
-|---|---|
-| Example  | [![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/tksoftware/cbs)  |
-| VolunteerReporting  | [![Build status](https://ci.appveyor.com/api/projects/status/o77909lns7ubfxdl?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs/build/1.1.0-30-nsotvffx)  |
-
+[![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/somthing)
 
 ## Prerequisites
 


### PR DESCRIPTION
This move the table with build status for each project into the main readme file.
When I added the table in PR #173 i put it in the wrong spot  