### PR TITLE
Change appveyor project url for Volunteer Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, take a look at this [video](https://youtu.be/pXkXyb6xTdE).
 | Projects  | AppVeyor status (Windows)  | CircleCI status (Linux) | TravisCI status (Linux)
 |---|---|---|---|
 | Example project  | [![Build status](https://ci.appveyor.com/api/projects/status/verl69fxww1xi5l3?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs-c5ssa)  | [![CircleCI](https://circleci.com/gh/sheeeng/cbs.png?style=shield&circle-token=df3dc5f6efbc2a267f7805f05a5e91d2878be9fd)](https://circleci.com/gh/sheeeng/cbs) | [![TravisCI Status](https://travis-ci.org/sheeeng/cbs.svg?branch=master)](https://travis-ci.org/sheeeng/cbs)
-| Volunteer Reporting  | [![Build status](https://ci.appveyor.com/api/projects/status/o77909lns7ubfxdl?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs/build/1.1.0-30-nsotvffx)  |
+| Volunteer Reporting  | [![Build status](https://ci.appveyor.com/api/projects/status/o77909lns7ubfxdl?svg=true)](https://ci.appveyor.com/project/RFMoore/cbs)  |
 
 ## Contributing
 


### PR DESCRIPTION
The url that was used as a link in the build status badge for Volunteer Reporting at appveyor linked to the status of a spesific build not the overall project page.
