### PR TITLE
Update container image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,52 @@
-FROM microsoft/dotnet:latest
+FROM microsoft/dotnet:2-sdk-jessie
+
+# Install Mono
 
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get update \
   && apt-get install --yes \
-  curl \
-  gnupg \
+    curl \
+    gnupg \
   && apt-key adv \
-  --keyserver hkp://keyserver.ubuntu.com:80 \
-  --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    --keyserver hkp://keyserver.ubuntu.com:80 \
+    --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
-RUN echo "deb http://download.mono-project.com/repo/debian stretch main" \
+RUN echo "deb http://download.mono-project.com/repo/debian jessie main" \
   | tee /etc/apt/sources.list.d/mono-official.list
 
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get update \
   && apt-get install --yes \
-  mono-devel
+    mono-devel
+
+# Install PowerShell
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    apt-utils \
+    ca-certificates \
+    curl \
+    apt-transport-https \
+    locales
+
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -	
+RUN curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/microsoft.list
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    powershell
+
+# Install Node
+
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    nodejs
+
+# Clean
 
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get clean \


### PR DESCRIPTION
Install Mono, PowerShell, and Node.

Use Debian 8 Jessie instead of Debian 9 Stretch as base image as
[PowerShell repository](https://github.com/powershell/powershell/tree/master/docker/release) available [only](https://packages.microsoft.com/config/debian/) with Debian 8 Jessie.

These tools are installed in the container image:
```
# mono --version | head -1
Mono JIT compiler version 5.2.0.224 (tarball Tue Oct  3 19:51:58 UTC 2017)
# dotnet --version
2.0.2
# powershell --version
PowerShell v6.0.0-beta.8
# node --version
v8.6.0
# npm --version
5.3.0
```