### PR TITLE
Hook up backend and angular properly using proxy file

### DIFF
--- a/Source/Admin/Web.Angular/package.json
+++ b/Source/Admin/Web.Angular/package.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "scripts": {
         "ng": "ng",
-        "start": "ng serve",
+        "start": "ng serve --proxy-config proxy.conf.json",
         "build": "ng build",
         "test": "ng test",
         "lint": "ng lint",

--- a/Source/Admin/Web.Angular/proxy.conf.json
+++ b/Source/Admin/Web.Angular/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api": {
+        "target": "http://localhost:5000",
+        "secure": false
+    }
+}

--- a/Source/Admin/Web/Startup.cs
+++ b/Source/Admin/Web/Startup.cs
@@ -5,7 +5,6 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/Source/Alert/Web.Angular/package.json
+++ b/Source/Alert/Web.Angular/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/Source/Alert/Web.Angular/proxy.conf.json
+++ b/Source/Alert/Web.Angular/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api": {
+        "target": "http://localhost:5000",
+        "secure": false
+    }
+}

--- a/Source/Alert/Web.Angular/readme.md
+++ b/Source/Alert/Web.Angular/readme.md
@@ -16,7 +16,7 @@ Restore dependencies
 
 Build and host locally
 
-> `ng serve` or `npm start`
+> `npm start`
 
 ## Scaffold new Angular components
 

--- a/Source/Alert/Web/Startup.cs
+++ b/Source/Alert/Web/Startup.cs
@@ -1,16 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2017 International Federation of Red Cross. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace Web
 {
     public class Startup : Infrastructure.AspNet.Startup
     {
         public Startup(
-            ILoggerFactory loggerFactory, 
-            IHostingEnvironment env, 
+            ILoggerFactory loggerFactory,
+            IHostingEnvironment env,
             IConfiguration configuration) : base(loggerFactory, env, configuration)
         {
         }
@@ -22,6 +28,17 @@ namespace Web
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.Use(async (context, next) =>
+            {
+                await next();
+
+                if (context.Response.StatusCode == 404 && !Path.HasExtension(context.Request.Path.Value))
+                {
+                    context.Request.Path = "/index.html";
+                    await next();
+                }
+            });
+
             app.UseCommon(env);
         }
     }

--- a/Source/Example/Catalog/Web.Angular/package.json
+++ b/Source/Example/Catalog/Web.Angular/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/Source/Example/Catalog/Web.Angular/proxy.conf.json
+++ b/Source/Example/Catalog/Web.Angular/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api": {
+        "target": "http://localhost:5000",
+        "secure": false
+    }
+}

--- a/Source/Example/Catalog/Web.Angular/src/app/cart/cart.service.ts
+++ b/Source/Example/Catalog/Web.Angular/src/app/cart/cart.service.ts
@@ -13,7 +13,7 @@ export class CartService {
   constructor(private http: Http) { }
 
   saveToCart(item: GroceryItem): Promise<void> {
-    const url = `http://localhost:5000/api/shopping/cart/items`;
+    const url = `/api/shopping/cart/items`;
 
     const addItemToCart = new AddItemToCart();
     addItemToCart.product = item.id;

--- a/Source/Example/Catalog/Web/Startup.cs
+++ b/Source/Example/Catalog/Web/Startup.cs
@@ -1,16 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2017 International Federation of Red Cross. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace Web
 {
     public class Startup : Infrastructure.AspNet.Startup
     {
         public Startup(
-            ILoggerFactory loggerFactory, 
-            IHostingEnvironment env, 
+            ILoggerFactory loggerFactory,
+            IHostingEnvironment env,
             IConfiguration configuration) : base(loggerFactory, env, configuration)
         {
         }
@@ -22,6 +28,17 @@ namespace Web
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.Use(async (context, next) =>
+            {
+                await next();
+
+                if (context.Response.StatusCode == 404 && !Path.HasExtension(context.Request.Path.Value))
+                {
+                    context.Request.Path = "/index.html";
+                    await next();
+                }
+            });
+
             app.UseCommon(env);
         }
     }

--- a/Source/Example/readme.md
+++ b/Source/Example/readme.md
@@ -51,7 +51,7 @@ Restore dependencies
 > `npm install`
 
 Build and host locally
-> `ng serve` or `npm start`
+> `npm start`
 
 Open http://localhost:4200/ in your browser to access the UI. 
 

--- a/Source/UserManagement/Web.Angular/package.json
+++ b/Source/UserManagement/Web.Angular/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/Source/UserManagement/Web.Angular/proxy.conf.json
+++ b/Source/UserManagement/Web.Angular/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api": {
+        "target": "http://localhost:5000",
+        "secure": false
+    }
+}

--- a/Source/UserManagement/Web.Angular/readme.md
+++ b/Source/UserManagement/Web.Angular/readme.md
@@ -16,7 +16,7 @@ Restore dependencies
 
 Build and host locally
 
-> `ng serve` or `npm start`
+> `npm start`
 
 ## Scaffold new Angular components
 

--- a/Source/UserManagement/Web/Startup.cs
+++ b/Source/UserManagement/Web/Startup.cs
@@ -1,16 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2017 International Federation of Red Cross. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace Web
 {
     public class Startup : Infrastructure.AspNet.Startup
     {
         public Startup(
-            ILoggerFactory loggerFactory, 
-            IHostingEnvironment env, 
+            ILoggerFactory loggerFactory,
+            IHostingEnvironment env,
             IConfiguration configuration) : base(loggerFactory, env, configuration)
         {
         }
@@ -22,6 +28,17 @@ namespace Web
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.Use(async (context, next) =>
+            {
+                await next();
+
+                if (context.Response.StatusCode == 404 && !Path.HasExtension(context.Request.Path.Value))
+                {
+                    context.Request.Path = "/index.html";
+                    await next();
+                }
+            });
+
             app.UseCommon(env);
         }
     }

--- a/Source/VolunteerReporting/Web.Angular/package.json
+++ b/Source/VolunteerReporting/Web.Angular/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/Source/VolunteerReporting/Web.Angular/proxy.conf.json
+++ b/Source/VolunteerReporting/Web.Angular/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+    "/api": {
+        "target": "http://localhost:5000",
+        "secure": false
+    }
+}

--- a/Source/VolunteerReporting/Web.Angular/readme.md
+++ b/Source/VolunteerReporting/Web.Angular/readme.md
@@ -16,7 +16,7 @@ Restore dependencies
 
 Build and host locally
 
-> `ng serve` or `npm start`
+> `npm start`
 
 ## Scaffold new Angular components
 

--- a/Source/VolunteerReporting/Web/Startup.cs
+++ b/Source/VolunteerReporting/Web/Startup.cs
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) 2017 International Federation of Red Cross. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -10,8 +15,8 @@ namespace Web
     public class Startup : Infrastructure.AspNet.Startup
     {
         public Startup(
-            ILoggerFactory loggerFactory, 
-            IHostingEnvironment env, 
+            ILoggerFactory loggerFactory,
+            IHostingEnvironment env,
             IConfiguration configuration) : base(loggerFactory, env, configuration)
         {
         }

--- a/Source/VolunteerReporting/readme.md
+++ b/Source/VolunteerReporting/readme.md
@@ -53,7 +53,7 @@ Restore dependencies
 > `npm install`
 
 Build and host locally
-> `ng serve` or `npm start`
+> `npm start`
 
 Open http://localhost:4200/ in your browser to access the UI. 
 


### PR DESCRIPTION
I removed the use of `ng serve` and set up `npm start` to use a proxy file to forward all requests from the frontend to /api/* to locahost:5000/api/*. Would be great if one of you could confirm that this works well on your machines too.