### PR TITLE
#263 Updating build shields after recreating Admin build in AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, take a look at this [video](https://youtu.be/pXkXyb6xTdE).
 |---|---|---|---|
 | Example project  | [![Build status](https://ci.appveyor.com/api/projects/status/3s33gey8y08ynu4s/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-hjk90/branch/master)  | [![CircleCI](https://circleci.com/gh/sheeeng/cbs.png?style=shield&circle-token=df3dc5f6efbc2a267f7805f05a5e91d2878be9fd)](https://circleci.com/gh/sheeeng/cbs) | [![TravisCI Status](https://travis-ci.org/sheeeng/cbs.svg?branch=master)](https://travis-ci.org/sheeeng/cbs)
 | Volunteer Reporting  | [![Build status](https://ci.appveyor.com/api/projects/status/tt50700nylx40eml/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-g81xy/branch/master)  |
-| Admin  | [![Build status](https://ci.appveyor.com/api/projects/status/117990iba2ie13lp/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-xxsg0/branch/master)  |
+| Admin  | [![Build status](https://ci.appveyor.com/api/projects/status/5u26suwgd9co1rgp/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-0ntrh/branch/master)  |
 | User Management  | [![Build status](https://ci.appveyor.com/api/projects/status/yyxiq56hy52iyv50/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-83l5k/branch/master)  |
 | Alert  | [![Build status](https://ci.appveyor.com/api/projects/status/2lab71gqtq8hkxn8/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-q2clx/branch/master)  |
 

--- a/Source/Admin/readme.md
+++ b/Source/Admin/readme.md
@@ -1,4 +1,4 @@
 # Admin
 
 ## Build status
-[![Build status](https://ci.appveyor.com/api/projects/status/117990iba2ie13lp/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-xxsg0/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/5u26suwgd9co1rgp/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-0ntrh/branch/master)


### PR DESCRIPTION
All checks should now be green. Fixes #263.