### PR TITLE
Add tests for example project

### DIFF
--- a/Source/Example/Catalog/Catalog.sln
+++ b/Source/Example/Catalog/Catalog.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Web", "Web\Web.csproj", "{39FC4632-3667-463D-96E6-3F274B0C0163}"
 EndProject
@@ -21,6 +21,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure.Application", "..\..\Infrastructure\Application\Infrastructure.Application.csproj", "{CB35BBED-E267-4411-A652-CAE74F0A6C4A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure.Events.Web", "..\..\Infrastructure\Events.Web\Infrastructure.Events.Web.csproj", "{EBC48558-E4CB-487F-9EB8-560F5CEAA959}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests\Read.Tests", "Tests\Read.Tests\Read.Tests.csproj", "{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -152,6 +154,18 @@ Global
 		{EBC48558-E4CB-487F-9EB8-560F5CEAA959}.Release|x64.Build.0 = Release|Any CPU
 		{EBC48558-E4CB-487F-9EB8-560F5CEAA959}.Release|x86.ActiveCfg = Release|Any CPU
 		{EBC48558-E4CB-487F-9EB8-560F5CEAA959}.Release|x86.Build.0 = Release|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Debug|x64.Build.0 = Debug|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Debug|x86.Build.0 = Debug|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x64.ActiveCfg = Release|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x64.Build.0 = Release|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x86.ActiveCfg = Release|Any CPU
+		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Example/Catalog/Catalog.sln
+++ b/Source/Example/Catalog/Catalog.sln
@@ -22,7 +22,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure.Application"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure.Events.Web", "..\..\Infrastructure\Events.Web\Infrastructure.Events.Web.csproj", "{EBC48558-E4CB-487F-9EB8-560F5CEAA959}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests\Read.Tests", "Tests\Read.Tests\Read.Tests.csproj", "{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Read.Tests", "Tests\Read.Tests\Read.Tests.csproj", "{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain.Tests", "Tests\Domain.Tests\Domain.Tests.csproj", "{14E4CA4C-D41E-4373-A2C7-93E81735431B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -166,6 +168,18 @@ Global
 		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x64.Build.0 = Release|Any CPU
 		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x86.ActiveCfg = Release|Any CPU
 		{EBFC9709-C7CD-4B6B-9926-90F4C6BBAEC6}.Release|x86.Build.0 = Release|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Debug|x64.Build.0 = Debug|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Debug|x86.Build.0 = Debug|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Release|x64.ActiveCfg = Release|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Release|x64.Build.0 = Release|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Release|x86.ActiveCfg = Release|Any CPU
+		{14E4CA4C-D41E-4373-A2C7-93E81735431B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Example/Catalog/Read/Cart.cs
+++ b/Source/Example/Catalog/Read/Cart.cs
@@ -23,7 +23,7 @@ namespace Read
 
         public void Add(Guid product, int quantity, Price price)
         {
-            var existing = Lines.Where(p => p.Product == product).SingleOrDefault();
+            var existing = Lines.SingleOrDefault(p => p.Product == product);
             if (existing != null)
             {
                 existing.Quantity += quantity;

--- a/Source/Example/Catalog/Read/CartEventProcessors.cs
+++ b/Source/Example/Catalog/Read/CartEventProcessors.cs
@@ -4,7 +4,7 @@ namespace Read
 {
     public class CartEventProcessors : Infrastructure.Events.IEventProcessor
     {
-        readonly ICarts _carts;
+        private readonly ICarts _carts;
 
         public CartEventProcessors(ICarts carts)
         {
@@ -14,7 +14,7 @@ namespace Read
         public void Process(ItemAddedToCart @event)
         {
             var cart = _carts.GetById(@event.Cart);
-            cart.Add(@event.Product, @event.Quantity, new Price 
+            cart.Add(@event.Product, @event.Quantity, new Price
             {
                 Net = @event.NetItemPrice,
                 Gross = @event.GrossItemPrice

--- a/Source/Example/Catalog/Tests/Domain.Tests/AddItemToCartValidatorTests.cs
+++ b/Source/Example/Catalog/Tests/Domain.Tests/AddItemToCartValidatorTests.cs
@@ -1,0 +1,32 @@
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Domain.Tests
+{
+    public class AddItemToCartValidatorTests
+    {
+        private readonly AddItemToCartValidator _validator;
+
+        public AddItemToCartValidatorTests()
+        {
+            _validator = new AddItemToCartValidator();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-1337)]
+        public void AddItemToCartValidator_WhenQuantityIsZeroOrNegative_ShouldBeInvalid(int quantity)
+        {
+            _validator.ShouldHaveValidationErrorFor(item => item.Quantity, quantity);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(1337)]
+        public void AddItemToCartValidator_WhenQuantityIsPositive_ShouldBeValid(int quantity)
+        {
+            _validator.ShouldNotHaveValidationErrorFor(item => item.Quantity, quantity);
+        }
+    }
+}

--- a/Source/Example/Catalog/Tests/Domain.Tests/Domain.Tests.csproj
+++ b/Source/Example/Catalog/Tests/Domain.Tests/Domain.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Domain\Domain.csproj" />
+  </ItemGroup>
+
+  
+</Project>

--- a/Source/Example/Catalog/Tests/Read.Tests/CartEventProcessorsTests.cs
+++ b/Source/Example/Catalog/Tests/Read.Tests/CartEventProcessorsTests.cs
@@ -1,0 +1,117 @@
+using Events;
+using FakeItEasy;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Read.Tests
+{
+    public class CartEventProcessorsTests
+    {
+        private readonly ICarts _fakeCarts;
+        private readonly CartEventProcessors _cartEventProcessors;
+        private readonly Cart _testCart;
+
+        public CartEventProcessorsTests()
+        {
+            _fakeCarts = A.Fake<ICarts>();
+            _cartEventProcessors = new CartEventProcessors(_fakeCarts);
+
+            // Initialize an empty cart as a baseline for all tests
+            _testCart = new Cart
+            {
+                Id = Guid.NewGuid(),
+                Lines = new List<CartLine>()
+            };
+
+            // Arrange so test cart is always returned from processor
+            A.CallTo(() => _fakeCarts.GetById(A<Guid>._)).Returns(_testCart);
+        }
+
+        [Fact]
+        public void Process_WhenCartExists_ShouldAddProductToCart()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            var product = new ItemAddedToCart
+            {
+                GrossItemPrice = 129,
+                NetItemPrice = 99,
+                Product = productId,
+                Quantity = 1
+            };
+
+            // Act
+            _cartEventProcessors.Process(product);
+
+            // Assert
+            Assert.Single(_testCart.Lines);
+            Assert.Equal(1, _testCart.Lines.Single().Quantity);
+            Assert.Equal(129, _testCart.Lines.Single().Price.Gross);
+            Assert.Equal(99, _testCart.Lines.Single().Price.Net);
+            Assert.Equal(productId, _testCart.Lines.Single().Product);
+
+            A.CallTo(() => _fakeCarts.Save(A<Cart>._)).MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void Process_WhenAddingSameProductThreeTimes_ShouldOnlyIncreaseQuantityInCart()
+        {
+            // Arrange
+            var productId = Guid.NewGuid();
+            var product = new ItemAddedToCart
+            {
+                GrossItemPrice = 129,
+                NetItemPrice = 99,
+                Product = productId,
+                Quantity = 1
+            };
+
+            // Act
+            _cartEventProcessors.Process(product);
+            _cartEventProcessors.Process(product);
+            _cartEventProcessors.Process(product);
+
+            // Assert
+            Assert.Single(_testCart.Lines);
+            Assert.Equal(3, _testCart.Lines.Single().Quantity);
+            Assert.Equal(129, _testCart.Lines.Single().Price.Gross);
+            Assert.Equal(99, _testCart.Lines.Single().Price.Net);
+            Assert.Equal(productId, _testCart.Lines.Single().Product);
+
+            A.CallTo(() => _fakeCarts.Save(A<Cart>._)).MustHaveHappened(Repeated.Exactly.Times(3));
+        }
+
+        [Fact]
+        public void Process_WhenAddingTwoDifferentProducts_ShouldAddBothToCart()
+        {
+            // Arrange
+            var product1Id = Guid.NewGuid();
+            var product1 = new ItemAddedToCart
+            {
+                GrossItemPrice = 129,
+                NetItemPrice = 99,
+                Product = product1Id,
+                Quantity = 1
+            };
+
+            var product2Id = Guid.NewGuid();
+            var product2 = new ItemAddedToCart
+            {
+                GrossItemPrice = 449,
+                NetItemPrice = 399,
+                Product = product2Id,
+                Quantity = 1
+            };
+
+            // Act
+            _cartEventProcessors.Process(product1);
+            _cartEventProcessors.Process(product2);
+
+            // Assert
+            Assert.Equal(2, _testCart.Lines.Count());
+            A.CallTo(() => _fakeCarts.Save(A<Cart>._)).MustHaveHappened(Repeated.Exactly.Twice);
+        }
+    }
+}

--- a/Source/Example/Catalog/Tests/Read.Tests/Read.Tests.csproj
+++ b/Source/Example/Catalog/Tests/Read.Tests/Read.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="4.1.1" />
+    <PackageReference Include="xunit" Version="2.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+	<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Read\Read.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #214 

I have added two test projects to give examples of how validators and event processors can be tested using FakeItEasy and XUnit.

Only weird thing is I had to target `netcoreapp2.0` instead of `netstandard2.0` to get discovery of tests in Visual Studio working (using `xunit.runner.visualstudio`). Haven't dug into why this happens, but I believe @roarfred has the same issue.