### PR TITLE
Add basic docfx skeleton

### DIFF
--- a/Documentation/.gitignore
+++ b/Documentation/.gitignore
@@ -1,0 +1,8 @@
+# docfx ignores
+
+/**/DROP/
+/**/TEMP/
+/**/packages/
+/**/bin/
+/**/obj/
+_site

--- a/Documentation/Contribution/toc.yml
+++ b/Documentation/Contribution/toc.yml
@@ -1,0 +1,10 @@
+- name: Contributing
+  href: contributing.md
+- name: Development environment
+  href: development_environment.md
+- name: Documenting
+  href: documentation.md
+- name: Getting started
+  href: getting_started.md
+- name: Issues
+  href: issues.md  

--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "content": [
+      {
+        "files": [
+          "Contribution/**.md",
+          "Contribution/**/toc.yml",
+          "toc.yml",
+          "*.md"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "contribution/images/**"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
+        ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadata": {
+        "_disableContribution": true
+    },
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false
+  }
+}

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -1,0 +1,6 @@
+# **CBS Documentation**
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla suscipit libero sit amet metus vulputate, gravida vulputate lectus laoreet. Ut sed nibh non risus suscipit pulvinar. Nunc sit amet ex at enim pulvinar tincidunt id facilisis urna. Cras quis pretium ligula. Fusce venenatis tortor eget maximus sollicitudin. Aenean ac suscipit ligula. Ut pharetra turpis eu posuere egestas. Duis felis enim, aliquam id mi sed, interdum semper massa. Ut condimentum, sem varius scelerisque laoreet, orci urna ultrices mi, blandit dictum nunc nisi sed diam. Sed consectetur magna non nulla vulputate, a hendrerit nunc facilisis. Duis purus arcu, posuere in fermentum eget, fermentum in diam.
+
+Have a look at the [developer documentation](Contribution/getting_started.md)
+

--- a/Documentation/readme.md
+++ b/Documentation/readme.md
@@ -1,0 +1,6 @@
+## How to build the documentation site
+
+1. Download and unzip docfx https://github.com/dotnet/docfx/releases
+2. Add the folder with docfx in to your environment path
+3. With `\cbs\Documentation` as active folder, build and serve docs on http://localhost:8080 using   
+   `docfx --serve`

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -1,0 +1,3 @@
+- name: Developer documentation
+  href: Contribution/
+  homepage: Contribution/getting_started.md


### PR DESCRIPTION
First part of dynamically creating a documentation site based on docfx as described in #5 . 
So far it looks like this:

![image](https://user-images.githubusercontent.com/1311807/31861352-f8ecc0e2-b72b-11e7-9400-e1478e5d8a6d.png)

Remarks:
- Docfx reports broken links on build - which is really handy. And our docs already contain a lot of them!
- I haven't fully understood how to integrate docfx with appveyor. If we want to host the output static page on github pages, appveyor needs to commit the end result to our repo in some way.
- Please see the included readme.md on how to get this up and running locally.