### PR TITLE
Making sure the event processors are called in all scenarios

### DIFF
--- a/Source/Infrastructure/AspNet/CommandFilter.cs
+++ b/Source/Infrastructure/AspNet/CommandFilter.cs
@@ -8,20 +8,16 @@ namespace Infrastructure.AspNet
 {
     public class CommandFilter : ActionFilterAttribute
     {
-        static AsyncLocal<bool> _hasEstablishedCommandContext = new AsyncLocal<bool>();
-
         public override void OnActionExecuting(ActionExecutingContext context)
         {
             var commandContextManager = Internals.ServiceProvider.GetService(typeof(ICommandContextManager)) as ICommandContextManager;
             commandContextManager.EstablishForCommand(new CommandRequest(TransactionCorrelationId.New(),null, new Dictionary<string,object>()));
-            _hasEstablishedCommandContext.Value = true;
         }
 
-        public override void OnResultExecuted(ResultExecutedContext context)
+        public override void OnActionExecuted(ActionExecutedContext context)
         {
-            if( !_hasEstablishedCommandContext.Value ) return;
             var commandContextManager = Internals.ServiceProvider.GetService(typeof(ICommandContextManager)) as ICommandContextManager;
-            commandContextManager.GetCurrent().Commit();
+            if( commandContextManager.HasCurrent ) commandContextManager.GetCurrent().Commit();
         }
     }
 }


### PR DESCRIPTION
Fixes #299

It was using the wrong method - apparently when using `AsyncLocal<>`- it is out of scope when the result is executed. Not entirely sure why that is.