### PR TITLE
Updating dotnet image version and removing public service

### DIFF
--- a/Source/Admin/Web/Dockerfile
+++ b/Source/Admin/Web/Dockerfile
@@ -1,5 +1,5 @@
 # Build the .NET part
-FROM microsoft/dotnet:2.0.0-sdk AS dotnet-build
+FROM microsoft/dotnet:2.0-runtime AS dotnet-build
 WORKDIR /src
 COPY ./NuGet.Config ./
 COPY ./Build/MSBuild ./Build/MSBuild

--- a/Source/Admin/deploy/dev-deployment.yaml
+++ b/Source/Admin/deploy/dev-deployment.yaml
@@ -50,7 +50,6 @@ kind: Service
 metadata:
   name: cbs-admin-backend
 spec:
-  type: LoadBalancer
   ports:
   - port: 80
   selector:

--- a/Source/UserManagement/Web/Dockerfile
+++ b/Source/UserManagement/Web/Dockerfile
@@ -1,5 +1,5 @@
 # Build the .NET part
-FROM microsoft/dotnet:2.0.0-sdk AS dotnet-build
+FROM microsoft/dotnet:2.0-runtime AS dotnet-build
 WORKDIR /src
 COPY ./NuGet.Config ./
 COPY ./Build/MSBuild ./Build/MSBuild

--- a/Source/UserManagement/deploy/dev-deployment.yaml
+++ b/Source/UserManagement/deploy/dev-deployment.yaml
@@ -50,7 +50,6 @@ kind: Service
 metadata:
   name: cbs-usermgmt-backend
 spec:
-  type: LoadBalancer
   ports:
   - port: 80
   selector:

--- a/Source/VolunteerReporting/Web/Dockerfile
+++ b/Source/VolunteerReporting/Web/Dockerfile
@@ -1,5 +1,5 @@
 # Build the .NET part
-FROM microsoft/dotnet:2.0.0-sdk AS dotnet-build
+FROM microsoft/dotnet:2.0-runtime AS dotnet-build
 WORKDIR /src
 COPY ./NuGet.Config ./
 COPY ./Build/MSBuild ./Build/MSBuild

--- a/Source/VolunteerReporting/deploy/dev-deployment.yaml
+++ b/Source/VolunteerReporting/deploy/dev-deployment.yaml
@@ -50,7 +50,6 @@ kind: Service
 metadata:
   name: cbs-volunteerreporting-backend
 spec:
-  type: LoadBalancer
   ports:
   - port: 80
   selector:


### PR DESCRIPTION
Releasing Public IPs in AKS (max 10 available)
Updating docker image version and using runtime image instead of sdk