### PR TITLE
Specifying version to 2.0.5

### DIFF
--- a/Source/Admin/Web/Dockerfile
+++ b/Source/Admin/Web/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0-runtime
+FROM microsoft/aspnetcore:2.0.5-runtime
 WORKDIR /app
 COPY --from=dotnet-build /src/Source/Admin/Web/out .
 ENTRYPOINT ["dotnet", "Web.dll"]

--- a/Source/UserManagement/Web/Dockerfile
+++ b/Source/UserManagement/Web/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0-runtime
+FROM microsoft/aspnetcore:2.0.5-runtime
 WORKDIR /app
 COPY --from=dotnet-build /src/Source/UserManagement/Web/out .
 ENTRYPOINT ["dotnet", "Web.dll"]

--- a/Source/VolunteerReporting/Web/Dockerfile
+++ b/Source/VolunteerReporting/Web/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0-runtime
+FROM microsoft/aspnetcore:2.0.5-runtime
 WORKDIR /app
 COPY --from=dotnet-build /src/Source/VolunteerReporting/Web/out .
 ENTRYPOINT ["dotnet", "Web.dll"]


### PR DESCRIPTION
Fixing the difference in dotnetcore image versions, forcing 2.0.5