### PR TITLE
If HealthRiskId is Guid.Empty, report an invalid message

### DIFF
--- a/Source/VolunteerReporting/TextMessaging/TextMessageProcessor.cs
+++ b/Source/VolunteerReporting/TextMessaging/TextMessageProcessor.cs
@@ -54,8 +54,13 @@ namespace TextMessaging
                 return;
             }
 
-            // Todo: Should we have a validation check if we actually get a health risk id
             var healthRiskId = _healthRisks.GetIdFromReadableId(parsingResult.Numbers[0]);
+            if (healthRiskId == Guid.Empty)
+            {
+                ReportInvalidMessage(message, parsingResult, dataCollector, caseReporting, message.Sent);
+                return;
+            }
+
             if (!parsingResult.HasMultipleCases)
             {
                 var malesUnder5 = 0;


### PR DESCRIPTION
Checking if a healthrisk is not found, and if so reporting an invalid message
Fixes #473