### PR TITLE
nginx proxy configuration

### DIFF
--- a/Deploy/Chart.yaml
+++ b/Deploy/Chart.yaml
@@ -1,0 +1,9 @@
+name: cbs
+version: 0.1.0
+appVersion: 0.1.0
+description: A chart containing all deployment files needed to deploy cbs
+sources:
+  - http://github.com/IFRCGo/cbs/
+maintainers:
+  - name: karolikl
+    email: karolikl@gmail.com

--- a/Deploy/templates/admin.yaml
+++ b/Deploy/templates/admin.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: cbs-admin-backend
-        image: karolikl/cbs-admin-backend:{{services.admin.backend.version}}
+        image: karolikl/cbs-admin-backend:{{ .Values.services.admin.backend.version }}
         ports:
         - containerPort: 80
 ---
@@ -69,14 +69,14 @@ spec:
     spec:
       containers:
       - name: cbs-admin-frontend
-        image: karolikl/cbs-admin-frontend:{{services.admin.frontend.version}}
+        image: karolikl/cbs-admin-frontend:{{ .Values.services.admin.frontend.version }}
         ports:
         - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{services.admin.name}}
+  name: {{ .Values.services.admin.name }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/admin.yaml
+++ b/Deploy/templates/admin.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: cbs-admin-backend
-        image: karolikl/cbs-admin-backend:$BUILD_ID
+        image: karolikl/cbs-admin-backend:{{services.admin.backend.version}}
         ports:
         - containerPort: 80
 ---
@@ -69,14 +69,14 @@ spec:
     spec:
       containers:
       - name: cbs-admin-frontend
-        image: karolikl/cbs-admin-frontend:$BUILD_ID
+        image: karolikl/cbs-admin-frontend:{{services.admin.frontend.version}}
         ports:
         - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {services.admin.name}
+  name: {{services.admin.name}}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/admin.yaml
+++ b/Deploy/templates/admin.yaml
@@ -48,7 +48,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name:   name: {{ .Values.services.admin.backend.service }}
+  name: {{ .Values.services.admin.backend.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/admin.yaml
+++ b/Deploy/templates/admin.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-admin-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-admin-db
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-admin-db
+        image: mongo
+        ports:
+        - containerPort: 27017
+          name: mongo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbs-admin-db
+spec:
+  ports:
+  - port: 27017
+  selector:
+    app: cbs-admin-db
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-admin-backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-admin-backend
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-admin-backend
+        image: karolikl/cbs-admin-backend:$BUILD_ID
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbs-admin-backend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: cbs-admin-backend
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-admin-frontend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-admin-frontend
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-admin-frontend
+        image: karolikl/cbs-admin-frontend:$BUILD_ID
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {services.admin.name}
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+  selector:
+    app: cbs-admin-frontend

--- a/Deploy/templates/admin.yaml
+++ b/Deploy/templates/admin.yaml
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.services.admin.service }}
+  name: {{ .Values.services.admin.frontend.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/admin.yaml
+++ b/Deploy/templates/admin.yaml
@@ -48,8 +48,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cbs-admin-backend
+  name:   name: {{ .Values.services.admin.backend.service }}
 spec:
+  type: NodePort
   ports:
   - port: 80
   selector:
@@ -76,7 +77,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.services.admin.name }}
+  name: {{ .Values.services.admin.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/default-http-backend.yaml
+++ b/Deploy/templates/default-http-backend.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  labels:
+    k8s-app: default-http-backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  labels:
+    k8s-app: default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    k8s-app: default-http-backend

--- a/Deploy/templates/nginx-deployment.yaml
+++ b/Deploy/templates/nginx-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nginx-ingress-controller
   labels:
     k8s-app: nginx-ingress-controller
-  namespace: kube-system
 spec:
   replicas: 1
   template:

--- a/Deploy/templates/nginx-deployment.yaml
+++ b/Deploy/templates/nginx-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       # Check latest version here: https://github.com/kubernetes/ingress-nginx/releases
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.4
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.10.2
         name: nginx-ingress-controller        
         ports:
         - containerPort: 80

--- a/Deploy/templates/nginx-deployment.yaml
+++ b/Deploy/templates/nginx-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  labels:
+    k8s-app: nginx-ingress-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-controller
+      annotations:
+        prometheus.io/port: '10254'
+        prometheus.io/scrape: 'true'
+    spec:
+      # hostNetwork makes it possible to use ipv6 and to preserve the source IP correctly regardless of docker configuration
+      # however, it is not a hard dependency of the nginx-ingress-controller itself and it may cause issues if port 10254 already is taken on the host
+      # that said, since hostPort is broken on CNI (https://github.com/kubernetes/kubernetes/issues/31307) we have to use hostNetwork where CNI is used
+      # like with kubeadm
+      # hostNetwork: true
+      # Check latest version here: https://github.com/kubernetes/ingress-nginx/releases
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.11.0
+        name: nginx-ingress-controller        
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend   

--- a/Deploy/templates/nginx-deployment.yaml
+++ b/Deploy/templates/nginx-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       # Check latest version here: https://github.com/kubernetes/ingress-nginx/releases
       terminationGracePeriodSeconds: 60
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.11.0
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.4
         name: nginx-ingress-controller        
         ports:
         - containerPort: 80

--- a/Deploy/templates/nginx-deployment.yaml
+++ b/Deploy/templates/nginx-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx-ingress-controller
   labels:
     k8s-app: nginx-ingress-controller
+  namespace: default
 spec:
   replicas: 1
   template:

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -10,6 +10,18 @@ spec:
   - host: test.cbsrc.org
     http:
       paths:      
+      - path: {{ .Values.services.usermanagement.backend.path }}
+        backend:
+          serviceName: {{ .Values.services.usermanagement.name }}
+          servicePort: 80
+      - path: {{ .Values.services.volunteerreporting.backend.path }}
+        backend:
+          serviceName: {{ .Values.services.volunteerreporting.name }}
+          servicePort: 80
+      - path: {{ .Values.services.admin.backend.path }}
+        backend:
+          serviceName: {{ .Values.services.admin.name }}
+          servicePort: 80
       - path: {{ .Values.services.usermanagement.path }}
         backend:
           serviceName: {{ .Values.services.usermanagement.name }}

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -10,15 +10,15 @@ spec:
   - host: test.cbsrc.org
     http:
       paths:      
-      - path: {services.usermanagement.path}
+      - path: {{services.usermanagement.path}}
         backend:
-          serviceName: {services.usermanagement.name}
+          serviceName: {{services.usermanagement.name}}
           servicePort: 80
-      - path: {services.volunteerreporting.path}
+      - path: {{services.volunteerreporting.path}}
         backend:
-          serviceName: {services.volunteerreporting.name}
+          serviceName: {{services.volunteerreporting.name}}
           servicePort: 80
-      - path: {services.admin.path}
+      - path: {{services.admin.path}}
         backend:
-          serviceName: {services.admin.name}
+          serviceName: {{services.admin.name}}
           servicePort: 80

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -4,7 +4,8 @@ metadata:
   name: nginx-ingress  
   annotations:    
     kubernetes.io/ingress.class: nginx
-    ingress.kubernetes.io/rewrite-target: /
+    # ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:  
   rules:
   - host: test.cbsrc.org

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -12,25 +12,25 @@ spec:
       paths:      
       - path: {{ .Values.services.usermanagement.backend.path }}
         backend:
-          serviceName: {{ .Values.services.usermanagement.name }}
+          serviceName: {{ .Values.services.usermanagement.backend.service }}
           servicePort: 80
       - path: {{ .Values.services.volunteerreporting.backend.path }}
         backend:
-          serviceName: {{ .Values.services.volunteerreporting.name }}
+          serviceName: {{ .Values.services.volunteerreporting.backend.service }}
           servicePort: 80
       - path: {{ .Values.services.admin.backend.path }}
         backend:
-          serviceName: {{ .Values.services.admin.name }}
+          serviceName: {{ .Values.services.admin.backend.service }}
           servicePort: 80
       - path: {{ .Values.services.usermanagement.path }}
         backend:
-          serviceName: {{ .Values.services.usermanagement.name }}
+          serviceName: {{ .Values.services.usermanagement.service }}
           servicePort: 80
       - path: {{ .Values.services.volunteerreporting.path }}
         backend:
-          serviceName: {{ .Values.services.volunteerreporting.name }}
+          serviceName: {{ .Values.services.volunteerreporting.service }}
           servicePort: 80
       - path: {{ .Values.services.admin.path }}
         backend:
-          serviceName: {{ .Values.services.admin.name }}
+          serviceName: {{ .Values.services.admin.service }}
           servicePort: 80

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -22,15 +22,15 @@ spec:
         backend:
           serviceName: {{ .Values.services.admin.backend.service }}
           servicePort: 80
-      - path: {{ .Values.services.usermanagement.path }}
+      - path: {{ .Values.services.usermanagement.frontend.path }}
         backend:
-          serviceName: {{ .Values.services.usermanagement.service }}
+          serviceName: {{ .Values.services.usermanagement.frontend.service }}
           servicePort: 80
-      - path: {{ .Values.services.volunteerreporting.path }}
+      - path: {{ .Values.services.volunteerreporting.frontend.path }}
         backend:
-          serviceName: {{ .Values.services.volunteerreporting.service }}
+          serviceName: {{ .Values.services.volunteerreporting.frontend.service }}
           servicePort: 80
-      - path: {{ .Values.services.admin.path }}
+      - path: {{ .Values.services.admin.frontend.path }}
         backend:
-          serviceName: {{ .Values.services.admin.service }}
+          serviceName: {{ .Values.services.admin.frontend.service }}
           servicePort: 80

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nginx-ingress  
+  annotations:    
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/rewrite-target: /
+spec:  
+  rules:
+  - host: test.cbsrc.org
+    http:
+      paths:      
+      - path: {services.usermanagement.path}
+        backend:
+          serviceName: {services.usermanagement.name}
+          servicePort: 80
+      - path: {services.volunteerreporting.path}
+        backend:
+          serviceName: {services.volunteerreporting.name}
+          servicePort: 80
+      - path: {services.admin.path}
+        backend:
+          serviceName: {services.admin.name}
+          servicePort: 80

--- a/Deploy/templates/nginx-ingress.yaml
+++ b/Deploy/templates/nginx-ingress.yaml
@@ -10,15 +10,15 @@ spec:
   - host: test.cbsrc.org
     http:
       paths:      
-      - path: {{services.usermanagement.path}}
+      - path: {{ .Values.services.usermanagement.path }}
         backend:
-          serviceName: {{services.usermanagement.name}}
+          serviceName: {{ .Values.services.usermanagement.name }}
           servicePort: 80
-      - path: {{services.volunteerreporting.path}}
+      - path: {{ .Values.services.volunteerreporting.path }}
         backend:
-          serviceName: {{services.volunteerreporting.name}}
+          serviceName: {{ .Values.services.volunteerreporting.name }}
           servicePort: 80
-      - path: {{services.admin.path}}
+      - path: {{ .Values.services.admin.path }}
         backend:
-          serviceName: {{services.admin.name}}
+          serviceName: {{ .Values.services.admin.name }}
           servicePort: 80

--- a/Deploy/templates/nginx-service.yaml
+++ b/Deploy/templates/nginx-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingressservice
+  namespace: kube-system
+spec:
+  ports:
+    - port: 80
+      name: http
+    - port: 443
+      name: https
+  selector:
+    k8s-app: nginx-ingress-controller
+  type: LoadBalancer

--- a/Deploy/templates/nginx-service.yaml
+++ b/Deploy/templates/nginx-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ingressservice
-  namespace: kube-system
 spec:
   ports:
     - port: 80

--- a/Deploy/templates/usermanagement.yaml
+++ b/Deploy/templates/usermanagement.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: cbs-usermgmt-backend
-        image: karolikl/cbs-usermgmt-backend:{{services.usermanagement.backend.version}}
+        image: karolikl/cbs-usermgmt-backend:{{ .Values.services.usermanagement.backend.version }}
         ports:
         - containerPort: 80
 ---
@@ -69,14 +69,14 @@ spec:
     spec:
       containers:
       - name: cbs-usermgmt-frontend
-        image: karolikl/cbs-usermgmt-frontend:{{services.usermanagement.frontend.version}}
+        image: karolikl/cbs-usermgmt-frontend:{{ .Values.services.usermanagement.frontend.version }}
         ports:
         - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{services.usermanagement.name}}
+  name: {{ .Values.services.usermanagement.name }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/usermanagement.yaml
+++ b/Deploy/templates/usermanagement.yaml
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.services.usermanagement.service }}
+  name: {{ .Values.services.usermanagement.frontend.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/usermanagement.yaml
+++ b/Deploy/templates/usermanagement.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: cbs-usermgmt-backend
-        image: karolikl/cbs-usermgmt-backend:$BUILD_ID
+        image: karolikl/cbs-usermgmt-backend:{{services.usermanagement.backend.version}}
         ports:
         - containerPort: 80
 ---
@@ -69,14 +69,14 @@ spec:
     spec:
       containers:
       - name: cbs-usermgmt-frontend
-        image: karolikl/cbs-usermgmt-frontend:$BUILD_ID
+        image: karolikl/cbs-usermgmt-frontend:{{services.usermanagement.frontend.version}}
         ports:
         - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {services.usermanagement.name}
+  name: {{services.usermanagement.name}}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/usermanagement.yaml
+++ b/Deploy/templates/usermanagement.yaml
@@ -76,7 +76,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.services.usermanagement.name }}
+  name: {{ .Values.services.usermanagement.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/usermanagement.yaml
+++ b/Deploy/templates/usermanagement.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-usermgmt-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-usermgmt-db
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-usermgmt-db
+        image: mongo
+        ports:
+        - containerPort: 27017
+          name: mongo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbs-usermgmt-db
+spec:
+  ports:
+  - port: 27017
+  selector:
+    app: cbs-usermgmt-db
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-usermgmt-backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-usermgmt-backend
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-usermgmt-backend
+        image: karolikl/cbs-usermgmt-backend:$BUILD_ID
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbs-usermgmt-backend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: cbs-usermgmt-backend
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-usermgmt-frontend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-usermgmt-frontend
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-usermgmt-frontend
+        image: karolikl/cbs-usermgmt-frontend:$BUILD_ID
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {services.usermanagement.name}
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+  selector:
+    app: cbs-usermgmt-frontend

--- a/Deploy/templates/usermanagement.yaml
+++ b/Deploy/templates/usermanagement.yaml
@@ -48,8 +48,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cbs-usermgmt-backend
+  name: {{ .Values.services.usermanagement.backend.service }}
 spec:
+  type: NodePort
   ports:
   - port: 80
   selector:

--- a/Deploy/templates/volunteerreporting.yaml
+++ b/Deploy/templates/volunteerreporting.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: cbs-volunteerreporting-backend
-        image: karolikl/cbs-vr-backend:$BUILD_ID
+        image: karolikl/cbs-vr-backend:{{services.volunteerreporting.backend.version}}
         ports:
         - containerPort: 80
 ---
@@ -69,14 +69,14 @@ spec:
     spec:
       containers:
       - name: cbs-volunteerreporting-frontend
-        image: karolikl/cbs-vr-frontend:$BUILD_ID
+        image: karolikl/cbs-vr-frontend:{{services.volunteerreporting.frontend.version}}
         ports:
         - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {services.volunteerreporting.name}
+  name: {{services.volunteerreporting.name}}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/volunteerreporting.yaml
+++ b/Deploy/templates/volunteerreporting.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: cbs-volunteerreporting-backend
-        image: karolikl/cbs-vr-backend:{{services.volunteerreporting.backend.version}}
+        image: karolikl/cbs-vr-backend:{{ .Values.services.volunteerreporting.backend.version }}
         ports:
         - containerPort: 80
 ---
@@ -69,14 +69,14 @@ spec:
     spec:
       containers:
       - name: cbs-volunteerreporting-frontend
-        image: karolikl/cbs-vr-frontend:{{services.volunteerreporting.frontend.version}}
+        image: karolikl/cbs-vr-frontend:{{ .Values.services.volunteerreporting.frontend.version }}
         ports:
         - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{services.volunteerreporting.name}}
+  name: {{ .Values.services.volunteerreporting.name }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/volunteerreporting.yaml
+++ b/Deploy/templates/volunteerreporting.yaml
@@ -48,8 +48,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cbs-volunteerreporting-backend
+  name: {{ .Values.services.volunteerreporting.backend.service }}
 spec:
+  type: NodePort
   ports:
   - port: 80
   selector:

--- a/Deploy/templates/volunteerreporting.yaml
+++ b/Deploy/templates/volunteerreporting.yaml
@@ -77,7 +77,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.services.volunteerreporting.service }}
+  name: {{ .Values.services.volunteerreporting.frontend.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/templates/volunteerreporting.yaml
+++ b/Deploy/templates/volunteerreporting.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-volunteerreporting-db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-volunteerreporting-db
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-volunteerreporting-db
+        image: mongo
+        ports:
+        - containerPort: 27017
+          name: mongo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbs-volunteerreporting-db
+spec:
+  ports:
+  - port: 27017
+  selector:
+    app: cbs-volunteerreporting-db
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-volunteerreporting-backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-volunteerreporting-backend
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-volunteerreporting-backend
+        image: karolikl/cbs-vr-backend:$BUILD_ID
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cbs-volunteerreporting-backend
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: cbs-volunteerreporting-backend
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cbs-volunteerreporting-frontend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cbs-volunteerreporting-frontend
+        environment: dev
+    spec:
+      containers:
+      - name: cbs-volunteerreporting-frontend
+        image: karolikl/cbs-vr-frontend:$BUILD_ID
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {services.volunteerreporting.name}
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+  selector:
+    app: cbs-volunteerreporting-frontend

--- a/Deploy/templates/volunteerreporting.yaml
+++ b/Deploy/templates/volunteerreporting.yaml
@@ -76,7 +76,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.services.volunteerreporting.name }}
+  name: {{ .Values.services.volunteerreporting.service }}
 spec:
   type: NodePort
   ports:

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -3,11 +3,23 @@ services:
         name: admin
         service: cbs-admin-frontend-service
         path: /
+        frontend:
+            version: 1413
+        backend:
+            version: 1414
     usermanagement:
         name: usermanagement
         service: cbs-usermanagement-frontend-service
         path: /users
+        frontend:
+            version: 1415
+        backend:
+            version: 1415
     volunteerreporting:
         name: volunteerreporting
         service: cbs-volunteerreporting-frontend-service
         path: /reporting
+        frontend:
+            version: 1414
+        backend:
+            version: 1413

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -7,6 +7,8 @@ services:
             version: 1414
         backend:
             version: 1414
+            path: /adminbackend
+            service: cbs-volunteerreporting-backend-service
     usermanagement:
         name: usermanagement
         service: cbs-usermanagement-frontend-service
@@ -15,6 +17,8 @@ services:
             version: 1415
         backend:
             version: 1415
+            path: /usermanagementbackend
+            service: cbs-usermanagement-backend-service
     volunteerreporting:
         name: volunteerreporting
         service: cbs-volunteerreporting-frontend-service
@@ -23,3 +27,5 @@ services:
             version: 1413
         backend:
             version: 1413
+            path: /volunteerreportingbackend
+            service: cbs-volunteerreporting-backend-service

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -1,31 +1,28 @@
 services: 
     admin:
-        name: admin
-        service: cbs-admin-frontend-service
-        path: /
         frontend:
             version: 1414
+            service: cbs-admin-frontend-service
+            path: /
         backend:
             version: 1414
             path: /adminbackend
-            service: cbs-volunteerreporting-backend
+            service: cbs-volunteerreporting-backend-service
     usermanagement:
-        name: usermanagement
-        service: cbs-usermanagement-frontend-service
-        path: /users
         frontend:
             version: 1415
+            service: cbs-usermanagement-frontend-service
+            path: /users
         backend:
             version: 1415
             path: /usermanagementbackend
-            service: cbs-usermanagement-backend
+            service: cbs-usermanagement-backend-service
     volunteerreporting:
-        name: volunteerreporting
-        service: cbs-volunteerreporting-frontend-service
-        path: /reporting
         frontend:
             version: 1413
+            service: cbs-volunteerreporting-frontend-service
+            path: /reporting
         backend:
             version: 1413
             path: /volunteerreportingbackend
-            service: cbs-volunteerreporting-backend
+            service: cbs-volunteerreporting-backend-service

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -7,7 +7,7 @@ services:
         backend:
             version: 1414
             path: /adminbackend
-            service: cbs-volunteerreporting-backend-service
+            service: cbs-admin-backend-service
     usermanagement:
         frontend:
             version: 1415

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -1,0 +1,13 @@
+services: 
+    admin:
+        name: admin
+        service: cbs-admin-frontend-service
+        path: /
+    usermanagement:
+        name: usermanagement
+        service: cbs-usermanagement-frontend-service
+        path: /users
+    volunteerreporting:
+        name: volunteerreporting
+        service: cbs-volunteerreporting-frontend-service
+        path: /reporting

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -8,7 +8,7 @@ services:
         backend:
             version: 1414
             path: /adminbackend
-            service: cbs-volunteerreporting-backend-service
+            service: cbs-volunteerreporting-backend
     usermanagement:
         name: usermanagement
         service: cbs-usermanagement-frontend-service
@@ -18,7 +18,7 @@ services:
         backend:
             version: 1415
             path: /usermanagementbackend
-            service: cbs-usermanagement-backend-service
+            service: cbs-usermanagement-backend
     volunteerreporting:
         name: volunteerreporting
         service: cbs-volunteerreporting-frontend-service
@@ -28,4 +28,4 @@ services:
         backend:
             version: 1413
             path: /volunteerreportingbackend
-            service: cbs-volunteerreporting-backend-service
+            service: cbs-volunteerreporting-backend

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -4,7 +4,7 @@ services:
         service: cbs-admin-frontend-service
         path: /
         frontend:
-            version: 1413
+            version: 1414
         backend:
             version: 1414
     usermanagement:
@@ -20,6 +20,6 @@ services:
         service: cbs-volunteerreporting-frontend-service
         path: /reporting
         frontend:
-            version: 1414
+            version: 1413
         backend:
             version: 1413

--- a/Source/UserManagement/Web.Angular/Dockerfile
+++ b/Source/UserManagement/Web.Angular/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src
 WORKDIR /src
 RUN ["yarn", "install"]
-RUN ["ng", "build", "--prod"]
+RUN ["ng", "build", "--prod --base-ref /users/"]
 
 FROM nginx:1.13-alpine
 COPY --from=angular-build /src/dist /usr/share/nginx/html

--- a/Source/VolunteerReporting/Web.Angular/Dockerfile
+++ b/Source/VolunteerReporting/Web.Angular/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src
 WORKDIR /src
 RUN ["yarn", "install"]
-RUN ["ng", "build", "--prod"]
+RUN ["ng", "build", "--prod --base-ref /reporting/"]
 
 FROM nginx:1.13-alpine
 COPY --from=angular-build /src/dist /usr/share/nginx/html


### PR DESCRIPTION
Changes done: 
- Added nginx ingress controller to route all traffic through the nginx proxy
- Added Helm chart so that all future deployments can be done with Helm
- In frontend Docker images, build using --base-href to serve static content from subpaths

After this PR has been completed, you can add 40.118.30.231 test.cbsrc.org to your hosts file and access all resources in the following way: 
test.cbsrc.org -> Admin frontend
test.cbsrc.org/users -> User Management frontend
test.cbsrc.org/reporting -> Volunteer Reporting frontend
test.cbsrc.org/adminbackend -> Admin backend
test.cbsrc.org/usermanagementbackend -> User Management backend
test.cbsrc.org/volunteerreportingbackend -> Volunteer Reporting backend

Next steps: 
- Add SSL certificate and create a record for test.cbsrc.org
- Deploy using Helm and Brigade
- Rename paths to e.g. /api/admin or similar when we have verified that the configuration works as expected, the current paths are rhubarb...
- Update list of maintainers, not quite sure who should be on it?
- Add all k8 yaml files to the Helm chart templates folder. 