### PR TITLE
Specifying Cake version as builds are currently breaking due to conflicting dependencies in Cake.Npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ Thumbs.db
 
 #Build tools #
 ##############
-Build/tools/
+Build/tools/Addins
+Build/tools/Cake
+Build/tools/nuget.exe
+Build/tools/packages.config.md5sum
 .buildsettings

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,5 @@ Thumbs.db
 
 #Build tools #
 ##############
-Build/tools/Addins
-Build/tools/Cake
-Build/tools/nuget.exe
-Build/tools/packages.config.md5sum
+Build/tools/
 .buildsettings

--- a/Build/tools/packages.config
+++ b/Build/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.23.0" />
+</packages>


### PR DESCRIPTION
Cake.Npm uses an older version of Cake (v 0.23.0), while our builds download the newest version (0.26.0). 

This results in the following exception at the moment: 
Cake.exe : Error: The assembly 'Cake.Npm, Version=0.12.1.0, Culture=neutral, PublicKeyToken=null' 
At C:\projects\cbs-0nrw1\Build\build.ps1:233 char:1
+ &$CAKE_EXE $cakeArguments
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (Error: The asse...KeyToken=null' :String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
is referencing an older version of Cake.Core (0.22.0). 
This assembly need to reference at least Cake.Core version 0.26.0. 
Another option is to downgrade Cake to an earlier version. 
It's not recommended, but you can explicitly opt-out of assembly verification 
by configuring the Skip Verification setting to true
(i.e. command line parameter "--settings_skipverification=true", 
environment variable "CAKE_SETTINGS_SKIPVERIFICATION=true", 
read more about configuration at https://cakebuild.net/docs/fundamentals/configuration)

This PR specifies that we want to use version 0.23.0 until Cake.Npm has been updated, and _should_ therefore fix our breaking builds. 