### PR TITLE
Typo: should be --base-href, not --base-ref

### DIFF
--- a/Source/UserManagement/Web.Angular/Dockerfile
+++ b/Source/UserManagement/Web.Angular/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src
 WORKDIR /src
 RUN ["yarn", "install"]
-RUN ["ng", "build", "--prod --base-ref /users/"]
+RUN ["ng", "build", "--prod --base-href /users/"]
 
 FROM nginx:1.13-alpine
 COPY --from=angular-build /src/dist /usr/share/nginx/html

--- a/Source/VolunteerReporting/Web.Angular/Dockerfile
+++ b/Source/VolunteerReporting/Web.Angular/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src
 WORKDIR /src
 RUN ["yarn", "install"]
-RUN ["ng", "build", "--prod --base-ref /reporting/"]
+RUN ["ng", "build", "--prod --base-href /reporting/"]
 
 FROM nginx:1.13-alpine
 COPY --from=angular-build /src/dist /usr/share/nginx/html


### PR DESCRIPTION
Fixing typo in dockerfiles for VolunteerReporting frontend and User Management frontend.