### PR TITLE
Fixes #492 - updated docker images to fix the ng build args

### DIFF
--- a/Source/UserManagement/Web.Angular/Dockerfile
+++ b/Source/UserManagement/Web.Angular/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src
 WORKDIR /src
 RUN ["yarn", "install"]
-RUN ["ng", "build", "--prod --base-href /users/"]
+RUN ["ng", "build", "--prod", "--base-href=/users/", "--deploy-url=/users/"]
 
 FROM nginx:1.13-alpine
 COPY --from=angular-build /src/dist /usr/share/nginx/html

--- a/Source/VolunteerReporting/Web.Angular/Dockerfile
+++ b/Source/VolunteerReporting/Web.Angular/Dockerfile
@@ -7,7 +7,7 @@ RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src
 WORKDIR /src
 RUN ["yarn", "install"]
-RUN ["ng", "build", "--prod --base-href /reporting/"]
+RUN ["ng", "build", "--prod", "--base-href=/reporting/", "--deploy-url=/reporting/"]
 
 FROM nginx:1.13-alpine
 COPY --from=angular-build /src/dist /usr/share/nginx/html


### PR DESCRIPTION
Updated the docker images to fix the `ng build` arguments.