### PR TITLE
Possible runtime fix for #532

### DIFF
--- a/Source/Infrastructure/AspNet/doLittleModule.cs
+++ b/Source/Infrastructure/AspNet/doLittleModule.cs
@@ -44,7 +44,7 @@ namespace Infrastructure.AspNet
             builder.RegisterInstance(Internals.AssemblyProvider).As<IAssemblyProvider>();
             builder.RegisterInstance(Internals.Assemblies).As<IAssemblies>();
 
-            Internals.Assemblies.GetAll().ForEach(assembly => builder.RegisterAssemblyTypes(assembly).AsSelf().AsImplementedInterfaces());
+            //Internals.Assemblies.GetAll().ForEach(assembly => builder.RegisterAssemblyTypes(assembly).AsSelf().AsImplementedInterfaces());
 
             builder.RegisterType<Container>().As<doLittle.DependencyInversion.IContainer>().SingleInstance();
             builder.RegisterType<UncommittedEventStreamCoordinator>().As<IUncommittedEventStreamCoordinator>()


### PR DESCRIPTION
Autofac does something that seems very strange.
It needs a bit more investigation. But it invokes something that
actually is not supposed to get invoked somehow.

An assembly provider that provides assemblies on disk - which
is not needed.

Anywho, this line of code was put in a few days ago to get self
binding working and it was not good. Need the Self registration source
thing instead.


**Please check if the PR fulfills these requirements**

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #issuenumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.