### PR TITLE
Making it failsafe if there is no bounded context topic configured

### DIFF
--- a/Source/Infrastructure/Kafka.BoundedContexts/BoundedContextListener.cs
+++ b/Source/Infrastructure/Kafka.BoundedContexts/BoundedContextListener.cs
@@ -154,13 +154,30 @@ namespace Infrastructure.Kafka.BoundedContexts
 
         public void Start()
         {
-            _consumer.SubscribeTo($"BoundedContextListenerFor_{_configuration.Topic}",_configuration.Topic, Received);
+            try 
+            {
+                if( _configuration.Topic == string.Empty ) 
+                {
+                    _logger.Warning("Missing topic - won't get events from other bounded contexts");
+                    return;
+                }
+                _consumer.SubscribeTo($"BoundedContextListenerFor_{_configuration.Topic}",_configuration.Topic, Received);
+            } catch( Exception ex ) 
+            {
+                _logger.Error(ex, "Failed subscribing to topics");
+            }
         }
 
         public static void Start(IServiceProvider serviceProvider)
         {
-            var listener = serviceProvider.GetService(typeof(IBoundedContextListener)) as IBoundedContextListener;
-            listener.Start();
+            try 
+            { 
+                var listener = serviceProvider.GetService(typeof(IBoundedContextListener)) as IBoundedContextListener;
+                listener.Start();
+            } catch( Exception ex )
+            {
+                Logger.Internal.Error(ex, "Problem starting bounded context listener");
+            }
         }
     }
 }


### PR DESCRIPTION
After several attempts, I do feel more confident saying that this should fix #532 and #544.

I understand why its happening, but don't understand the difference in behavior from a development environment to running inside a container. 

Basically, if one does not have `KAFKA_BOUNDED_CONTEXT_TOPIC`environment variable sent into the container at runtime it crashes. While in Development outside a container it does not. 
I didn't see this as obvious as I have my own scripts I run locally that sets this all up correctly when running containers. 

Also worth noting is that `KAFKA_BOUNDED_CONTEXT_SEND_TOPICS`- which is a `;`separated list of topics that can also be configured that will tell the running instance to commit any events occuring to those topics as well. This is how it all fits together.

(I do think documentation is in order...   Pssst.. Anyone..?? ) 🥇 