### PR TITLE
Putting in a self binding registration source

### DIFF
--- a/Source/Infrastructure/AspNet/doLittleModule.cs
+++ b/Source/Infrastructure/AspNet/doLittleModule.cs
@@ -22,6 +22,7 @@ using doLittle.Runtime.Events.Storage;
 using doLittle.Runtime.Execution;
 using doLittle.Runtime.Tenancy;
 using doLittle.Types;
+using Autofac.Features.ResolveAnything;
 
 namespace Infrastructure.AspNet
 {
@@ -29,6 +30,10 @@ namespace Infrastructure.AspNet
     {
         protected override void Load(ContainerBuilder builder)
         {
+            var selfBindingRegistrationSource = new AnyConcreteTypeNotAlreadyRegisteredSource(type => 
+                !type.Namespace.StartsWith("Microsoft") &&
+                !type.Namespace.StartsWith("System"));
+            
             var logAppenders = LoggingConfigurator.DiscoverAndConfigure(Internals.LoggerFactory);
             doLittle.Logging.ILogger logger = new Logger(logAppenders);
             builder.RegisterType<Logger>().As<doLittle.Logging.ILogger>().SingleInstance();
@@ -43,6 +48,8 @@ namespace Infrastructure.AspNet
             builder.RegisterInstance(Internals.AssembliesConfiguration).As<AssembliesConfiguration>();
             builder.RegisterInstance(Internals.AssemblyProvider).As<IAssemblyProvider>();
             builder.RegisterInstance(Internals.Assemblies).As<IAssemblies>();
+
+            builder.RegisterType<ConvertersProvider>().AsSelf();
 
             //Internals.Assemblies.GetAll().ForEach(assembly => builder.RegisterAssemblyTypes(assembly).AsSelf().AsImplementedInterfaces());
 


### PR DESCRIPTION
The registration source does not catch everything - so not entirely sure it actually works. 
But I got things working by adding a self binding for `ConvertersProvider`.
Need to investigate Autofac and its lack of cooperation

