### PR TITLE
Make Testdata generator simpler and more flexible

### DIFF
--- a/Source/UserManagement/Domain.Specs/StaffUser/Registering/given/commands.cs
+++ b/Source/UserManagement/Domain.Specs/StaffUser/Registering/given/commands.cs
@@ -1,6 +1,5 @@
 using Domain.StaffUser;
 using Domain.StaffUser.Registering;
-using System.Collections.Generic;
 using System;
 using Concepts;
 using doLittle.Commands;

--- a/Source/UserManagement/Read/DataCollectors/DataCollectorEventProcessor.cs
+++ b/Source/UserManagement/Read/DataCollectors/DataCollectorEventProcessor.cs
@@ -34,6 +34,7 @@ namespace Read.DataCollectors
 
         public void Process(DataCollectorUpdated @event)
         {
+            //TODO: Should be replaced with a new system
             var dataCollector = _dataCollectors.GetById(@event.DataCollectorId);
 
             dataCollector.FullName = @event.FullName;

--- a/Source/UserManagement/Read/StaffUsers/StaffUsers.cs
+++ b/Source/UserManagement/Read/StaffUsers/StaffUsers.cs
@@ -69,19 +69,27 @@ namespace Read.StaffUsers
             var filter = Builders<BaseUser>.Filter.OfType<T>();
             var cursor = await _collection.FindAsync(filter);
             var res = await cursor.ToListAsync();
-            //TODO: This should be safe..
+            // This should be safe..
             return res.Cast<T>().ToList();
 
         }
 
         public void Remove(Guid id)
         {
-            _collection.DeleteOne(_ => _.StaffUserId == id);
+            var res = _collection.DeleteOne(_ => _.StaffUserId == id);
+            if (res.DeletedCount == 0)
+            {
+                throw new UserNotFound($"StaffUser with id {id} was not found");
+            }
         }
 
         public async Task RemoveAsync(Guid id)
         {
-            await _collection.DeleteOneAsync(_ => _.StaffUserId == id);
+            var res =  await _collection.DeleteOneAsync(_ => _.StaffUserId == id);
+            if (res.DeletedCount == 0)
+            {
+                throw new UserNotFound($"StaffUser with id {id} was not found");
+            }
         }
 
         public void Save<T>(T dataCollector) where T : BaseUser

--- a/Source/UserManagement/Web/Controllers/DataCollectorsController.cs
+++ b/Source/UserManagement/Web/Controllers/DataCollectorsController.cs
@@ -1,18 +1,11 @@
-using Domain;
-using Events;
 using Infrastructure.AspNet;
 using Microsoft.AspNetCore.Mvc;
-using Read;
 using Read.DataCollectors;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using doLittle.Domain;
 using Domain.DataCollector.Registering;
-using Domain.DataCollector.PhoneNumber;
 using Domain.DataCollector.Update;
 using Domain.DataCollector;
-using MongoDB.Driver;
 
 // For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -53,6 +46,8 @@ namespace Web.Controllers
         [HttpPost("update")]
         public IActionResult Update([FromBody] UpdateDataCollector command)
         {
+            // TODO: Changes has to be made to updating the datacollector.
+            // Should use the same system as staffusers
             _dataCollectorCommandHandler.Handle(command);
             return Ok();
         }

--- a/Source/UserManagement/Web/Controllers/TestDataGeneratorController.cs
+++ b/Source/UserManagement/Web/Controllers/TestDataGeneratorController.cs
@@ -23,8 +23,7 @@ namespace Web.Controllers
         private readonly IMongoDatabase _database;
         private readonly Domain.DataCollector.IDataCollectorCommandHandler _dataCollectorCommandHandler;
         private readonly IRegisteringCommandHandlers _staffUserCommandHandler;
-
-        private readonly IStaffUsers _staffUsers;
+        
 
         public TestDataGeneratorController(
             IMongoDatabase database,
@@ -36,7 +35,6 @@ namespace Web.Controllers
             _database = database;
             _staffUserCommandHandler = staffUserCommandHandler;
             _dataCollectorCommandHandler = dataCollectorCommandHandler;
-            _staffUsers = staffUsers;
         }
 
         [HttpGet("generatetestdataset")]
@@ -93,7 +91,7 @@ namespace Web.Controllers
         [HttpGet("alladminusercommands")]
         public void CreateAllAdminUserCommands()
         {
-            //Delete Admin collection
+            DeleteAllAdmins();
             RegisterNewAdminUser[] commands;
             try
             {
@@ -115,7 +113,7 @@ namespace Web.Controllers
         [HttpGet("alldataconsumercommands")]
         public void CreateAllDataConsumerCommands()
         {
-            //Delete DataConsumer collection
+            DeleteAllDataConsumers();
             RegisterNewStaffDataConsumer[] commands;
             try
             {
@@ -137,7 +135,7 @@ namespace Web.Controllers
         [HttpGet("alldatacoordinatorcommands")]
         public void CreateAllDataCoordinatorCommands()
         {
-            //Delete DataCoordinator collection
+            DeleteAllDataCoordinators();
             RegisterNewDataCoordinator[] commands;
             try
             {
@@ -159,7 +157,7 @@ namespace Web.Controllers
         [HttpGet("alldataownercommands")]
         public void CreateAllDataOwnerCommands()
         {
-            //Delete DataOwner collection
+            DeleteAllDataOwners();
             RegisterNewDataOwner[] commands;
             try
             {
@@ -181,7 +179,7 @@ namespace Web.Controllers
         [HttpGet("alldataverifiercommands")]
         public void CreateAllDataVerifierCommands()
         {
-            //Delete DataVerifier collection
+            DeleteAllDataVerifiers();
             RegisterNewStaffDataVerifier[] commands;
             try
             {
@@ -203,7 +201,7 @@ namespace Web.Controllers
         [HttpGet("allsystemconfiguratorcommands")]
         public void CreateAllSystemConfiguratorCommands()
         {
-            //Delete SystemConfigurator collection
+            DeleteAllSystemConfigurators();
             RegisterNewSystemConfigurator[] commands;
             try
             {
@@ -239,6 +237,7 @@ namespace Web.Controllers
             DeleteCollection<BaseUser>("StaffUsers");
         }
 
+        #region Have not tested if this works, on TODO list
         [HttpGet("deletealladmins")]
         public void DeleteAllAdmins()
         {
@@ -275,6 +274,7 @@ namespace Web.Controllers
             DeleteCollection<SystemConfigurator>("StaffUsers");
         }
 
+        #endregion
 
         [HttpGet("deletedatacollectorcollection")]
         public void DeleteDataCollector()

--- a/Source/UserManagement/Web/TestData/Admins.json
+++ b/Source/UserManagement/Web/TestData/Admins.json
@@ -1,130 +1,162 @@
 [
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin0",
-      "DisplayName": "Admin0_Display_Name",
-      "Email": "Admin0@mail.com"
+      "StaffUserId": "dc5536e4-d24b-40e6-b983-aa6f90bdbb4e",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin1",
-      "DisplayName": "Admin1_Display_Name",
-      "Email": "Admin1@mail.com"
+      "StaffUserId": "9f974734-0f9e-4cdf-b8cd-266f5ff95d49",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin2",
-      "DisplayName": "Admin2_Display_Name",
-      "Email": "Admin2@mail.com"
+      "StaffUserId": "35e3ed12-95cc-4f35-b71c-980ca4b750fd",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin3",
-      "DisplayName": "Admin3_Display_Name",
-      "Email": "Admin3@mail.com"
+      "StaffUserId": "12f16175-7111-4359-a6b4-8be2d945fd8b",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin4",
-      "DisplayName": "Admin4_Display_Name",
-      "Email": "Admin4@mail.com"
+      "StaffUserId": "3e856fff-c6b7-49f6-9734-d2792d8a4308",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin5",
-      "DisplayName": "Admin5_Display_Name",
-      "Email": "Admin5@mail.com"
+      "StaffUserId": "198bf52f-3f40-48f8-81b2-b7fdc2f997cd",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin6",
-      "DisplayName": "Admin6_Display_Name",
-      "Email": "Admin6@mail.com"
+      "StaffUserId": "af80ab93-2ea4-412b-a1e2-e06c1610e707",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin7",
-      "DisplayName": "Admin7_Display_Name",
-      "Email": "Admin7@mail.com"
+      "StaffUserId": "eb10ec6d-1942-41f9-b852-d4884abc6c23",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin8",
-      "DisplayName": "Admin8_Display_Name",
-      "Email": "Admin8@mail.com"
+      "StaffUserId": "b9e7f247-0e0e-4882-8784-e82818e16e0a",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin9",
-      "DisplayName": "Admin9_Display_Name",
-      "Email": "Admin9@mail.com"
+      "StaffUserId": "fc238e58-7da7-4f10-bc1c-9596913bdfac",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin10",
-      "DisplayName": "Admin10_Display_Name",
-      "Email": "Admin10@mail.com"
+      "StaffUserId": "2672ef52-62c8-4ef5-8e2b-f3fb5f4a8a80",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin11",
-      "DisplayName": "Admin11_Display_Name",
-      "Email": "Admin11@mail.com"
+      "StaffUserId": "2a3b07f6-067d-482a-9a30-a568db553781",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin12",
-      "DisplayName": "Admin12_Display_Name",
-      "Email": "Admin12@mail.com"
+      "StaffUserId": "be39817f-764e-4b23-bf40-edea0e64894e",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin13",
-      "DisplayName": "Admin13_Display_Name",
-      "Email": "Admin13@mail.com"
+      "StaffUserId": "784dd237-e998-4842-9b17-afef200ed819",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin14",
-      "DisplayName": "Admin14_Display_Name",
-      "Email": "Admin14@mail.com"
+      "StaffUserId": "157b9f3d-76c1-402e-97e0-627840d556e2",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "StaffUserId": "00000000-0000-0000-0000-000000000000",
-      "FullName": "Admin15",
-      "DisplayName": "Admin15_Display_Name",
-      "Email": "Admin15@mail.com"
+      "StaffUserId": "1fae3125-55fe-4181-ba61-7c8c9e9b31b3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "StaffUserId": "a103573f-f72a-4bd0-8d19-b86ddf3e7f52",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "StaffUserId": "ea0b37bc-427b-4938-92ff-1b6c6ceb5a13",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "StaffUserId": "52dd706e-9b1b-4370-a6ee-de396ad56b99",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "StaffUserId": "f327632f-84c9-4a2c-8236-a873eee1996f",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   }
 ]

--- a/Source/UserManagement/Web/TestData/DataCollectors.json
+++ b/Source/UserManagement/Web/TestData/DataCollectors.json
@@ -1,50 +1,50 @@
 [
   {
-    "DataCollectorId": "00000000-0000-0000-0000-000000000000",
+    "DataCollectorId": "2b4f667e-a756-4081-9c6d-a2bc2cec45db",
     "FullName": "Abraham Watson",
-    "DisplayName": "Abraham_WatsonDISP",
-    "YearOfBirth": 1975,
-    "Sex": 2,
-    "NationalSociety": "886cbd86-10b5-45fa-aa28-0638345d6f6b",
-    "PreferredLanguage": 1,
-    "GpsLocation": {
-      "Latitude": 0.081062285732972569,
-      "Longitude": 0.60551931970078465
-    },
-    "PhoneNumbers": [
-      "93838519"
-    ]
-  },
-  {
-    "DataCollectorId": "00000000-0000-0000-0000-000000000000",
-    "FullName": "Vanessa Wallace",
-    "DisplayName": "Vanessa_WallaceDISP",
+    "DisplayName": "Abraham Watson_Disp",
     "YearOfBirth": 1980,
     "Sex": 1,
-    "NationalSociety": "621a7902-b451-435b-b58d-5bceac0da3c5",
-    "PreferredLanguage": 1,
+    "NationalSociety": "c0c7f0f5-d2dd-4ab8-88d9-3ff0c035def0",
+    "PreferredLanguage": 0,
     "GpsLocation": {
-      "Latitude": 0.80754166460015886,
-      "Longitude": 0.67066718203512354
+      "Latitude": 123.0,
+      "Longitude": 123.0
     },
     "PhoneNumbers": [
-      "4703227"
+      "123456789"
     ]
   },
   {
-    "DataCollectorId": "00000000-0000-0000-0000-000000000000",
-    "FullName": "Billie Mclaughlin",
-    "DisplayName": "Billie_MclaughlinDISP",
-    "YearOfBirth": 1939,
+    "DataCollectorId": "55574967-136f-414a-b722-7fe220b05f53",
+    "FullName": "Vanessa Wallace",
+    "DisplayName": "Vanessa Wallace_Disp",
+    "YearOfBirth": 1980,
     "Sex": 1,
-    "NationalSociety": "00683ad2-51ba-4a4d-94c2-c58eda949054",
-    "PreferredLanguage": 1,
+    "NationalSociety": "9f4f07c0-9482-4783-a6a0-e3cc47b933bd",
+    "PreferredLanguage": 0,
     "GpsLocation": {
-      "Latitude": 0.87685682479145788,
-      "Longitude": 0.84285357400907834
+      "Latitude": 123.0,
+      "Longitude": 123.0
     },
     "PhoneNumbers": [
-      "3055170"
+      "123456789"
+    ]
+  },
+  {
+    "DataCollectorId": "70b703ce-a020-45ea-b9f8-c739adfd55bf",
+    "FullName": "Billie Mclaughlin",
+    "DisplayName": "Billie Mclaughlin_Disp",
+    "YearOfBirth": 1980,
+    "Sex": 1,
+    "NationalSociety": "45201e14-a54b-48c0-b808-a2e88502ba43",
+    "PreferredLanguage": 0,
+    "GpsLocation": {
+      "Latitude": 123.0,
+      "Longitude": 123.0
+    },
+    "PhoneNumbers": [
+      "123456789"
     ]
   }
 ]

--- a/Source/UserManagement/Web/TestData/DataConsumers.json
+++ b/Source/UserManagement/Web/TestData/DataConsumers.json
@@ -2,289 +2,241 @@
   {
     "Role": {
       "Location": {
-        "Latitude": 0.63294948992922417,
-        "Longitude": 0.887341888568989
-      },
-      "Sex": 1,
-      "BirthYear": 1959,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 0,
-      "StaffUserId": "4570850c-f72f-4bcb-9ebc-084df13f792f",
-      "FullName": "DataConsumer0",
-      "DisplayName": "DataConsumer0 Display name",
-      "Email": "DataConsumer0@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.33736335874412365,
-        "Longitude": 0.9472491843380263
-      },
-      "Sex": 2,
-      "BirthYear": 1979,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "StaffUserId": "23ff0d79-0a77-4bb1-b830-028a6b997584",
-      "FullName": "DataConsumer1",
-      "DisplayName": "DataConsumer1 Display name",
-      "Email": "DataConsumer1@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.54333068036629384,
-        "Longitude": 0.14054031490373439
-      },
-      "Sex": 2,
-      "BirthYear": 1971,
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 0,
-      "StaffUserId": "e0e39dfa-fcde-4b4d-a34c-baa8958cdf4c",
-      "FullName": "DataConsumer2",
-      "DisplayName": "DataConsumer2 Display name",
-      "Email": "DataConsumer2@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.9481426877659479,
-        "Longitude": 0.23744914971173237
-      },
-      "Sex": 2,
-      "BirthYear": 1998,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 0,
-      "StaffUserId": "2d27cb51-52bb-4ae0-8953-559c7a51b4b6",
-      "FullName": "DataConsumer3",
-      "DisplayName": "DataConsumer3 Display name",
-      "Email": "DataConsumer3@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.6071116992305553,
-        "Longitude": 0.25030502548921157
-      },
-      "Sex": 1,
-      "BirthYear": 2007,
-      "NationalSociety": "55f764ee-8067-4131-8394-dfedd305d1b0",
-      "PreferredLanguage": 0,
-      "StaffUserId": "83b1e5ec-97a5-4cef-a89e-edc475a7549a",
-      "FullName": "DataConsumer4",
-      "DisplayName": "DataConsumer4 Display name",
-      "Email": "DataConsumer4@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.43025942492776525,
-        "Longitude": 0.57067178402592977
-      },
-      "Sex": 2,
-      "BirthYear": 1933,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "StaffUserId": "784d35d0-6a4e-44ef-90df-ad074f2428cc",
-      "FullName": "DataConsumer5",
-      "DisplayName": "DataConsumer5 Display name",
-      "Email": "DataConsumer5@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.38027893583303268,
-        "Longitude": 0.25583478447787222
-      },
-      "Sex": 2,
-      "BirthYear": 1931,
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 1,
-      "StaffUserId": "3200cea8-6fb0-41c9-af71-8c886df9a36d",
-      "FullName": "DataConsumer6",
-      "DisplayName": "DataConsumer6 Display name",
-      "Email": "DataConsumer6@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.80068500842930979,
-        "Longitude": 0.40557548329493753
-      },
-      "Sex": 2,
-      "BirthYear": 1973,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "StaffUserId": "7a04eadc-7c4e-413e-b641-b6c9f2881b57",
-      "FullName": "DataConsumer7",
-      "DisplayName": "DataConsumer7 Display name",
-      "Email": "DataConsumer7@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.96534765277306911,
-        "Longitude": 0.68957620984389267
-      },
-      "Sex": 1,
-      "BirthYear": 2007,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "StaffUserId": "68a99c58-0a8d-4d21-b953-351c82238383",
-      "FullName": "DataConsumer8",
-      "DisplayName": "DataConsumer8 Display name",
-      "Email": "DataConsumer8@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.847716266684102,
-        "Longitude": 0.899405307089633
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
       "Sex": null,
-      "BirthYear": 1958,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "StaffUserId": "4fe623ac-b6a6-4eda-8c0c-d7c95d71250f",
-      "FullName": "DataConsumer9",
-      "DisplayName": "DataConsumer9 Display name",
-      "Email": "DataConsumer9@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.54493741949318786,
-        "Longitude": 0.287725286692253
-      },
-      "Sex": 1,
-      "BirthYear": 1992,
-      "NationalSociety": "2d4f9fdc-712d-42f2-99c0-2828bf613cac",
-      "PreferredLanguage": 1,
-      "StaffUserId": "617eb144-4798-4a7d-9ecf-e2185ac8edfe",
-      "FullName": "DataConsumer10",
-      "DisplayName": "DataConsumer10 Display name",
-      "Email": "DataConsumer10@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.35090540365823797,
-        "Longitude": 0.23135833127021713
-      },
-      "Sex": 1,
-      "BirthYear": 1992,
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
+      "BirthYear": null,
+      "NationalSociety": "4081d9f1-5a55-40c5-b066-4ff845a91fd6",
       "PreferredLanguage": 0,
-      "StaffUserId": "e025fa2e-1cd5-4f8b-a605-7d38727ff046",
-      "FullName": "DataConsumer11",
-      "DisplayName": "DataConsumer11 Display name",
-      "Email": "DataConsumer11@mail.com"
+      "StaffUserId": "cdc10c70-652e-491b-a25b-e23f20111b17",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
       "Location": {
-        "Latitude": 0.39755109296997593,
-        "Longitude": 0.50595950172560267
-      },
-      "Sex": 2,
-      "BirthYear": 1950,
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
-      "PreferredLanguage": 0,
-      "StaffUserId": "aca2c9d2-5476-4a4b-8563-4a422d2c62c9",
-      "FullName": "DataConsumer12",
-      "DisplayName": "DataConsumer12 Display name",
-      "Email": "DataConsumer12@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.22919601864609682,
-        "Longitude": 0.12606176181047304
-      },
-      "Sex": 1,
-      "BirthYear": 1961,
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
-      "PreferredLanguage": 1,
-      "StaffUserId": "6f44e6e0-afe6-44aa-b373-f260c8e2bdb4",
-      "FullName": "DataConsumer13",
-      "DisplayName": "DataConsumer13 Display name",
-      "Email": "DataConsumer13@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.011795772245058685,
-        "Longitude": 0.5708126898719057
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
       "Sex": null,
-      "BirthYear": 1932,
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 1,
-      "StaffUserId": "272273fa-f29a-473f-817c-b6b8f630d642",
-      "FullName": "DataConsumer14",
-      "DisplayName": "DataConsumer14 Display name",
-      "Email": "DataConsumer14@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.17834371336658658,
-        "Longitude": 0.76390590833681915
-      },
-      "Sex": 2,
-      "BirthYear": 1998,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "StaffUserId": "0699a856-461e-47e1-ac6b-e9cbc4210c65",
-      "FullName": "DataConsumer15",
-      "DisplayName": "DataConsumer15 Display name",
-      "Email": "DataConsumer15@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "Location": {
-        "Latitude": 0.38729438250292764,
-        "Longitude": 0.3154099263788247
-      },
-      "Sex": 2,
-      "BirthYear": 1929,
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
+      "BirthYear": null,
+      "NationalSociety": "1bead9bf-a9bd-4ace-ad47-03f804004ca6",
       "PreferredLanguage": 0,
-      "StaffUserId": "29fee45c-daf3-4bfd-8fdd-81b70135a6ac",
-      "FullName": "DataConsumer16",
-      "DisplayName": "DataConsumer16 Display name",
-      "Email": "DataConsumer16@mail.com"
+      "StaffUserId": "e6534d43-1446-415e-acdb-cf763f698d75",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
       "Location": {
-        "Latitude": 0.48216381318967966,
-        "Longitude": 0.39943599021035991
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "Sex": 1,
-      "BirthYear": 1984,
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "94e14b63-45df-4ad2-a0c7-3bbbab88b22e",
       "PreferredLanguage": 0,
-      "StaffUserId": "7ec433a1-485f-4986-91b5-434565d557fd",
-      "FullName": "DataConsumer17",
-      "DisplayName": "DataConsumer17 Display name",
-      "Email": "DataConsumer17@mail.com"
+      "StaffUserId": "dd46b786-7501-4c0b-b953-0782b5fb931a",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "a9c64c9b-6620-4724-8a77-1c9268a103c9",
+      "PreferredLanguage": 0,
+      "StaffUserId": "1380c5fa-34c7-4cb9-bdc8-4532727237d9",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "ba9d42f0-bb31-492e-ab6b-1db489b30a8d",
+      "PreferredLanguage": 0,
+      "StaffUserId": "f28b2d20-b9ad-4405-9832-c3aacf4354f9",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "ef5109e5-9cf1-4d53-9258-0cdb77c78351",
+      "PreferredLanguage": 0,
+      "StaffUserId": "ea7f59dd-35df-4587-891a-cb928e2d5623",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "46863bc1-bb94-4b0a-b9fc-ae7129c2eaad",
+      "PreferredLanguage": 0,
+      "StaffUserId": "5bca4dcc-3bfb-41ee-819a-1417333afc26",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "42dc0024-f619-4613-98b8-8de622ecc39c",
+      "PreferredLanguage": 0,
+      "StaffUserId": "7910e365-96f0-4e2d-b25d-d734c9fe1eff",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "6d420dd9-40e7-4c21-8793-a1e62209fb12",
+      "PreferredLanguage": 0,
+      "StaffUserId": "1698bc76-71ba-4dee-b990-672e07910ccc",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "58cf5149-3660-4675-b7e0-c908d13788aa",
+      "PreferredLanguage": 0,
+      "StaffUserId": "76c7d444-f93f-4568-8fb6-1ddc8cda62dd",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "5ce03745-4a00-4aa7-8ce9-37f870ff265a",
+      "PreferredLanguage": 0,
+      "StaffUserId": "fae2cafa-3643-4851-9e9f-20a4fc6eb8fe",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "1a142b98-be4d-496d-a17c-ab5526ad671b",
+      "PreferredLanguage": 0,
+      "StaffUserId": "98c91d95-b684-4f1c-b275-9e1a2fe887e3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "a6cb52ab-4e25-4bb7-b793-90aa055a7ac6",
+      "PreferredLanguage": 0,
+      "StaffUserId": "ce97f794-4d68-424d-9524-f591bb63e43f",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "b0e9db91-bf63-44d3-893b-0b8cec45f4f3",
+      "PreferredLanguage": 0,
+      "StaffUserId": "7d033308-2cdb-470e-9854-9d082846e487",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "Sex": null,
+      "BirthYear": null,
+      "NationalSociety": "677c32db-a663-416c-9fb1-d07a97178573",
+      "PreferredLanguage": 0,
+      "StaffUserId": "01addf4a-269e-4974-833f-96b19fb213b3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   }
 ]

--- a/Source/UserManagement/Web/TestData/DataCoordinators.json
+++ b/Source/UserManagement/Web/TestData/DataCoordinators.json
@@ -1,398 +1,422 @@
 [
   {
     "Role": {
-      "BirthYear": 1954,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
+        "e8389c80-d161-4d46-8473-f7014ebae976",
+        "3ae2b032-51da-4ef9-a75b-20f78b259fe4"
       ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "2312727"
-      ],
-      "StaffUserId": "d514c088-4c87-4e7f-97b1-40c03dd77d5d",
-      "FullName": "DataCoordinator0",
-      "DisplayName": "DataCoordinator0 Display name",
-      "Email": "DataCoordinator0@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1987,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "cec094bd-de50-45da-8ac9-0fc2fadbdf04"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
+      "NationalSociety": "f66ac46a-eeb4-4575-b9b2-b337dd100792",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "86422080"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "54895a16-8189-48c3-9b16-4a3261e78d00",
-      "FullName": "DataCoordinator1",
-      "DisplayName": "DataCoordinator1 Display name",
-      "Email": "DataCoordinator1@mail.com"
+      "StaffUserId": "621d635a-d184-4a16-9751-9c4653089047",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1950,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "bf4c9eb4-4660-4054-a61e-0627d1c8434c"
+        "93b6d1b0-2d4e-4185-baef-e406365c5ccf",
+        "6be81e88-2162-4351-b92e-d2786180e309"
       ],
-      "NationalSociety": "2d4f9fdc-712d-42f2-99c0-2828bf613cac",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "92914877"
-      ],
-      "StaffUserId": "dc890cf3-d7d6-4671-892f-4f99676ae4b9",
-      "FullName": "DataCoordinator2",
-      "DisplayName": "DataCoordinator2 Display name",
-      "Email": "DataCoordinator2@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1996,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7"
-      ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "47406511"
-      ],
-      "StaffUserId": "dd2e5afa-e88b-4695-bf2c-46cd9cd1bd75",
-      "FullName": "DataCoordinator3",
-      "DisplayName": "DataCoordinator3 Display name",
-      "Email": "DataCoordinator3@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1930,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "55f764ee-8067-4131-8394-dfedd305d1b0"
-      ],
-      "NationalSociety": "55f764ee-8067-4131-8394-dfedd305d1b0",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "87445603"
-      ],
-      "StaffUserId": "330fd387-d256-4281-9df6-50af3a973f66",
-      "FullName": "DataCoordinator4",
-      "DisplayName": "DataCoordinator4 Display name",
-      "Email": "DataCoordinator4@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1944,
-      "Sex": null,
-      "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "70670026"
-      ],
-      "StaffUserId": "f5dae26b-a906-4058-96fe-65c10efaee27",
-      "FullName": "DataCoordinator5",
-      "DisplayName": "DataCoordinator5 Display name",
-      "Email": "DataCoordinator5@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1972,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "69630369"
-      ],
-      "StaffUserId": "741873ef-5268-42b6-ae36-ede2e36d6dee",
-      "FullName": "DataCoordinator6",
-      "DisplayName": "DataCoordinator6 Display name",
-      "Email": "DataCoordinator6@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1982,
-      "Sex": null,
-      "AssignedNationalSocieties": [
-        "56b9c71f-f284-4de5-8aa1-6c706f254e4d"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
+      "NationalSociety": "701f0e6c-69c0-49cd-89b0-7f42d1ae8a74",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "58010141"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "b45fdfee-35de-461f-ad7f-a1ead9efb707",
-      "FullName": "DataCoordinator7",
-      "DisplayName": "DataCoordinator7 Display name",
-      "Email": "DataCoordinator7@mail.com"
+      "StaffUserId": "17fb4d5e-2f28-40bc-bf8a-cd2b8ff21038",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1934,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
+        "bb56dbb4-3395-430c-9599-5480694abf42",
+        "c961a007-9c24-4000-a974-ce38f7d46a66"
       ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 1,
+      "NationalSociety": "e81b7a6e-530b-4e7a-b003-ef586b5162b2",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "72449036"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "ff320b6c-949a-4941-a2fd-2a11a9c5e097",
-      "FullName": "DataCoordinator8",
-      "DisplayName": "DataCoordinator8 Display name",
-      "Email": "DataCoordinator8@mail.com"
+      "StaffUserId": "5be82697-7d21-404e-bd1d-32430e722103",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1920,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
+        "04d5d896-f387-44cd-af2c-02f1848567ea",
+        "f81a8061-c64b-4895-b9e1-69c2c165f1b5"
       ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 1,
+      "NationalSociety": "4cf9bfd1-afdd-47b6-817a-929f5b9b532d",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "30071458"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "8a8e25f0-2dfa-4e80-badf-7b281a85df31",
-      "FullName": "DataCoordinator9",
-      "DisplayName": "DataCoordinator9 Display name",
-      "Email": "DataCoordinator9@mail.com"
+      "StaffUserId": "d926e4ed-acde-4fca-951f-6ef1c98c367c",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1947,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "bf4c9eb4-4660-4054-a61e-0627d1c8434c"
-      ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "98226179"
-      ],
-      "StaffUserId": "c8091c93-95b6-4d64-8f4e-2db6e48e9027",
-      "FullName": "DataCoordinator10",
-      "DisplayName": "DataCoordinator10 Display name",
-      "Email": "DataCoordinator10@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1958,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
+        "0b1aafd6-6d72-4b2f-86a1-435c0d907631",
+        "03a9a10e-bd05-4c61-b9ee-a53073ef2e7c"
       ],
-      "NationalSociety": "56b9c71f-f284-4de5-8aa1-6c706f254e4d",
-      "PreferredLanguage": 1,
+      "NationalSociety": "01768867-887b-4c2d-80c9-cc76a7005aa2",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "15473358"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "278996a7-1c16-4c83-91eb-220888c52cb8",
-      "FullName": "DataCoordinator11",
-      "DisplayName": "DataCoordinator11 Display name",
-      "Email": "DataCoordinator11@mail.com"
+      "StaffUserId": "ddb06fa2-7897-4224-9361-311ec81cd8ad",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1950,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
+        "57ebafbb-e8fd-4036-b74d-5f141dac01f7",
+        "33d1b06c-768e-4fac-93c6-adf551d11e11"
       ],
-      "NationalSociety": "56b9c71f-f284-4de5-8aa1-6c706f254e4d",
+      "NationalSociety": "426a4627-79ca-45a1-8e04-94ed7c8dbd21",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "11963676"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "0b6fb71a-1927-4d41-b5ba-0a1ab706edac",
-      "FullName": "DataCoordinator12",
-      "DisplayName": "DataCoordinator12 Display name",
-      "Email": "DataCoordinator12@mail.com"
+      "StaffUserId": "fa26f672-3566-4366-be10-4a51c22e6396",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1942,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "13694321"
-      ],
-      "StaffUserId": "c03ec256-4431-4f01-b79a-556ddb2900bc",
-      "FullName": "DataCoordinator13",
-      "DisplayName": "DataCoordinator13 Display name",
-      "Email": "DataCoordinator13@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1959,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
-      ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 0,
-      "PhoneNumbers": [
-        "27283220"
-      ],
-      "StaffUserId": "37c659a3-a506-47a4-a0b7-78adc1f95cab",
-      "FullName": "DataCoordinator14",
-      "DisplayName": "DataCoordinator14 Display name",
-      "Email": "DataCoordinator14@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1990,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 0,
-      "PhoneNumbers": [
-        "65987768"
-      ],
-      "StaffUserId": "2730c964-f59e-4278-b20b-a2335aa8c753",
-      "FullName": "DataCoordinator15",
-      "DisplayName": "DataCoordinator15 Display name",
-      "Email": "DataCoordinator15@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1986,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7"
+        "14c35a22-77d2-4fbd-9a16-8902a6290cec",
+        "84c344b5-12a3-4e32-a41d-f425be08125a"
       ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
+      "NationalSociety": "7216ab67-5b94-41c2-aa9f-d857c5e5e091",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "88397306"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "7051d988-17a3-450d-b569-9efcdbf0ae45",
-      "FullName": "DataCoordinator16",
-      "DisplayName": "DataCoordinator16 Display name",
-      "Email": "DataCoordinator16@mail.com"
+      "StaffUserId": "4fb8b42b-3bfd-462d-b272-62bccdb28846",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1956,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 0,
-      "PhoneNumbers": [
-        "26104237"
-      ],
-      "StaffUserId": "73d138ce-586c-4c7c-beeb-12a8ff252135",
-      "FullName": "DataCoordinator17",
-      "DisplayName": "DataCoordinator17 Display name",
-      "Email": "DataCoordinator17@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1985,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
+        "a786a3b9-f398-418e-94df-feacea016ccd",
+        "67a82110-f845-41ea-aa5f-525d3cc7d5ef"
       ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
+      "NationalSociety": "1b26a84e-0e66-4237-b221-463612f4a82e",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "52283329"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "5cc641d7-dc9e-4ee2-b171-7c8a2a576922",
-      "FullName": "DataCoordinator18",
-      "DisplayName": "DataCoordinator18 Display name",
-      "Email": "DataCoordinator18@mail.com"
+      "StaffUserId": "d18a80b0-96f0-47ef-9e4d-302fb2a8fd00",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1964,
-      "Sex": 1,
+      "BirthYear": null,
+      "Sex": null,
       "AssignedNationalSocieties": [
-        "55f764ee-8067-4131-8394-dfedd305d1b0"
+        "5becdbd5-d79c-44ee-ab39-b91460d060d8",
+        "918c7246-91ea-4e67-b618-a9799e202a35"
       ],
-      "NationalSociety": "55f764ee-8067-4131-8394-dfedd305d1b0",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "37179673"
-      ],
-      "StaffUserId": "ef533540-f37d-4923-8732-7334346d9d8a",
-      "FullName": "DataCoordinator19",
-      "DisplayName": "DataCoordinator19 Display name",
-      "Email": "DataCoordinator19@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1974,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
-      ],
-      "NationalSociety": "5255406d-89bd-4480-9116-27f3caf45e1d",
+      "NationalSociety": "c65b416b-579f-4d81-8649-41fe423ca05b",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "26542429"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "1fa65456-b3c5-4972-8e8f-96721af5a376",
-      "FullName": "DataCoordinator20",
-      "DisplayName": "DataCoordinator20 Display name",
-      "Email": "DataCoordinator20@mail.com"
+      "StaffUserId": "29eddac0-6fa6-443d-a3ab-f778da9f1e53",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 2006,
-      "Sex": 2,
+      "BirthYear": null,
+      "Sex": null,
       "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
+        "ba394878-75b1-4fd9-9470-03e69297f8e1",
+        "117f649b-d793-4391-bcc7-560d265b9784"
       ],
-      "NationalSociety": "5255406d-89bd-4480-9116-27f3caf45e1d",
-      "PreferredLanguage": 1,
+      "NationalSociety": "78b21f5c-0516-4292-bbbd-3a4786ef7323",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "84244623"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "ff4d4a73-647a-4c24-97ae-f01e5a303c54",
-      "FullName": "DataCoordinator21",
-      "DisplayName": "DataCoordinator21 Display name",
-      "Email": "DataCoordinator21@mail.com"
+      "StaffUserId": "92054d07-34c0-47b6-9b05-7af0e2927ee7",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "5353bc2e-02cb-4dca-aabc-fd5f0d1bc69c",
+        "679acf21-32be-4cc4-ae1d-feaec7ca8464"
+      ],
+      "NationalSociety": "b3b7db1c-39c7-4ea5-93be-4f4746b491fa",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "04666b60-ae75-4fae-8e7e-9142c37045f0",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "9e1d58c5-5a5c-40c4-88f9-6c361562c250",
+        "b12ca097-6b07-4df8-9e2d-d3c6b72ca3a6"
+      ],
+      "NationalSociety": "403cad21-ae8c-482d-bbee-d8e7b903d34f",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "ca2351a7-cad0-4059-83cc-bae3b50729df",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "2557a15a-7e8a-422c-9585-1c9cd04a67c3",
+        "a3d54019-94fa-4195-af1a-b9b72f82d589"
+      ],
+      "NationalSociety": "68c59a91-90e7-4160-8956-c09ecfe1d69b",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "811ad8a2-dfd7-4192-b957-0affd4e7c259",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "446c8fb0-a00d-40fb-8856-1458afaaa948",
+        "b1611c0c-570c-4de6-8ae5-815db0ac01a8"
+      ],
+      "NationalSociety": "b9c4f1c2-280c-4b2f-bdaf-678d499b2cbc",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "565b5bde-f961-4585-ba3e-f2b556ad9724",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "b8c0d9f9-513b-4cd6-8c07-f6d8db437746",
+        "82b0a6af-860d-409d-8706-4b68c345f066"
+      ],
+      "NationalSociety": "c9cd7ca6-4382-4f1b-952f-98047d6d119b",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "cb4ead6d-5447-432c-9ffc-cd065345ac97",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "5ade17a4-1974-49c1-995e-fb93ecdaf0b3",
+        "936cabbd-c88c-4312-bad9-fbb15814ccdd"
+      ],
+      "NationalSociety": "9eb6af7e-f23d-4175-8ca2-8d7cabe0fa8e",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "bac1a122-e43d-49c1-bc2b-7a04210af40a",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "efc1b051-3799-4f00-bb80-51f163e09e71",
+        "86df778c-13d0-4bec-af6a-7f59756ea48c"
+      ],
+      "NationalSociety": "d2c6e822-c864-48b8-8c7e-408afaf536c8",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "bc1db53c-a737-48e5-bcea-b1df6b9575da",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "5f1dd723-33cc-4d4d-bff0-491cf24f744e",
+        "8fb0335e-f9a6-497f-a04b-180aaef4ac10"
+      ],
+      "NationalSociety": "26240b09-219e-4e43-aae0-ba5fe9bd77fb",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "59e49fdb-42b6-40b4-84bd-9aeccb9ab9a3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "1d61492a-d28b-4155-a7b0-32eae5536f40",
+        "33a66c19-154b-44d4-82f5-0fdd6ddfceed"
+      ],
+      "NationalSociety": "6e8bb03b-499d-45ef-a8b3-507312fb48e5",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "10dead0f-4347-4ca8-9c74-b185714d23b4",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "e1540bb9-0de0-4626-bf4d-4385f978573d",
+        "6daa604f-2ff4-44dd-b494-70c4fb8bf2a6"
+      ],
+      "NationalSociety": "926ca15e-7a9a-4ad2-a3f4-f656b4714d84",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "d8431a4c-601b-408b-bdfa-25ff7b2f1f5a",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "b2a888c9-6776-4e53-94bd-ae59ef97fe9d",
+        "5c2a2f24-88b6-41a3-a99a-abee8eab4044"
+      ],
+      "NationalSociety": "3e8a4379-cf28-46a4-95e3-455d6f68aad8",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "ace6e6dd-8fe1-439b-a72c-ac5301491bf3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   }
 ]

--- a/Source/UserManagement/Web/TestData/DataOwners.json
+++ b/Source/UserManagement/Web/TestData/DataOwners.json
@@ -1,362 +1,301 @@
 [
   {
     "Role": {
-      "BirthYear": 1921,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "cec094bd-de50-45da-8ac9-0fc2fadbdf04"
-      ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "68736922"
-      ],
-      "DutyStation": "Dutty Station0",
-      "Position": "Position0",
-      "Location": {
-        "Latitude": 0.5661675113095751,
-        "Longitude": 0.0597509416098478
-      },
-      "StaffUserId": "40059c2c-a889-4de7-9607-178fa6d13e82",
-      "FullName": "DataOwner0",
-      "DisplayName": "DataOwner0 Display name",
-      "Email": "DataOwner0@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1999,
+      "BirthYear": null,
       "Sex": null,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 1,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "610b2daa-4437-4c75-8aac-bfef8b466f77",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "63916774"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station1",
-      "Position": "Position1",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.45024248326674221,
-        "Longitude": 0.74245123506637811
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "014322ec-0ba3-472d-b11a-3e4b050ff081",
-      "FullName": "DataOwner1",
-      "DisplayName": "DataOwner1 Display name",
-      "Email": "DataOwner1@mail.com"
+      "StaffUserId": "59dc09f6-3885-435e-b415-92cd9a3bdfe1",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1935,
+      "BirthYear": null,
       "Sex": null,
-      "AssignedNationalSocieties": [
-        "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "44f033fb-a2b1-43b6-bfa3-c281c2960b50",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "95386204"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station2",
-      "Position": "Position2",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.15304454190332653,
-        "Longitude": 0.63862818043615122
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "308006dc-cfe0-4e08-8334-0d4f2668aab3",
-      "FullName": "DataOwner2",
-      "DisplayName": "DataOwner2 Display name",
-      "Email": "DataOwner2@mail.com"
+      "StaffUserId": "40ab230a-61cb-4816-8880-8bdd163947fd",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1955,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "56b9c71f-f284-4de5-8aa1-6c706f254e4d"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
-      "PreferredLanguage": 0,
-      "PhoneNumbers": [
-        "25377380"
-      ],
-      "DutyStation": "Dutty Station3",
-      "Position": "Position3",
-      "Location": {
-        "Latitude": 0.48774110269161924,
-        "Longitude": 0.31612087381823029
-      },
-      "StaffUserId": "d840b5b7-a5e7-405f-8212-7dc595eaa679",
-      "FullName": "DataOwner3",
-      "DisplayName": "DataOwner3 Display name",
-      "Email": "DataOwner3@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1999,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "55f764ee-8067-4131-8394-dfedd305d1b0"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
-      "PreferredLanguage": 0,
-      "PhoneNumbers": [
-        "16205037"
-      ],
-      "DutyStation": "Dutty Station4",
-      "Position": "Position4",
-      "Location": {
-        "Latitude": 0.22376233442861695,
-        "Longitude": 0.37662931036978464
-      },
-      "StaffUserId": "82bca52d-c513-4f65-9fc7-d2fa8fd98f73",
-      "FullName": "DataOwner4",
-      "DisplayName": "DataOwner4 Display name",
-      "Email": "DataOwner4@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1990,
+      "BirthYear": null,
       "Sex": null,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
-      "PreferredLanguage": 1,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "e522ac4e-a2ab-4f6d-99e9-5f4bfaa0b07b",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "40760908"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station5",
-      "Position": "Position5",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.55020715554720123,
-        "Longitude": 0.64290689148144187
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "bbb0103a-8a97-4d57-9f17-387a1c1cdea0",
-      "FullName": "DataOwner5",
-      "DisplayName": "DataOwner5 Display name",
-      "Email": "DataOwner5@mail.com"
+      "StaffUserId": "cde9c852-1b33-4c1d-94d6-b3c0fda4e6a5",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1988,
+      "BirthYear": null,
       "Sex": null,
-      "AssignedNationalSocieties": [
-        "bf4c9eb4-4660-4054-a61e-0627d1c8434c"
-      ],
-      "NationalSociety": "56b9c71f-f284-4de5-8aa1-6c706f254e4d",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "72783980"
-      ],
-      "DutyStation": "Dutty Station6",
-      "Position": "Position6",
-      "Location": {
-        "Latitude": 0.63546394306955112,
-        "Longitude": 0.94309545631664593
-      },
-      "StaffUserId": "c63592fd-92bf-463e-be33-394436d7483e",
-      "FullName": "DataOwner6",
-      "DisplayName": "DataOwner6 Display name",
-      "Email": "DataOwner6@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1965,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "12857236"
-      ],
-      "DutyStation": "Dutty Station7",
-      "Position": "Position7",
-      "Location": {
-        "Latitude": 0.22079725760072341,
-        "Longitude": 0.58461883225693312
-      },
-      "StaffUserId": "9434a380-0e5d-4c6c-9ad1-8b282313bc52",
-      "FullName": "DataOwner7",
-      "DisplayName": "DataOwner7 Display name",
-      "Email": "DataOwner7@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1974,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "33a0f1e4-6f59-4a4f-9cd6-de2e431a5239",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "74501100"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station8",
-      "Position": "Position8",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.85122460958139257,
-        "Longitude": 0.98581571643511567
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "14df949d-621e-4e79-bc1d-342e890ac334",
-      "FullName": "DataOwner8",
-      "DisplayName": "DataOwner8 Display name",
-      "Email": "DataOwner8@mail.com"
+      "StaffUserId": "a08da1a2-371a-49b7-ba63-627c78482d6b",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1947,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "cec094bd-de50-45da-8ac9-0fc2fadbdf04"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "86a8e535-7e90-4830-bf65-562a25578eb8",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "24648351"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station9",
-      "Position": "Position9",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.1089499281295342,
-        "Longitude": 0.56156357543615787
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "72982b04-1fc4-4d34-a389-8e18cba6b8a2",
-      "FullName": "DataOwner9",
-      "DisplayName": "DataOwner9 Display name",
-      "Email": "DataOwner9@mail.com"
+      "StaffUserId": "dce7b584-5e7f-4582-91a7-37a595313b90",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1934,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "cec094bd-de50-45da-8ac9-0fc2fadbdf04"
-      ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "13e9d501-d706-40b4-a6b3-8f6ce5f8b23e",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "49438060"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station10",
-      "Position": "Position10",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.76515008684487551,
-        "Longitude": 0.61409393540308532
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "8c603ce3-f5e0-432e-a365-5952ef13b04b",
-      "FullName": "DataOwner10",
-      "DisplayName": "DataOwner10 Display name",
-      "Email": "DataOwner10@mail.com"
+      "StaffUserId": "e87bfe50-f352-42eb-bc0a-d6c87ea712f1",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1969,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "42f74cbc-8bb1-4c12-8eda-92cf399db8db",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "42498861"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station11",
-      "Position": "Position11",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.55033140515458367,
-        "Longitude": 0.72318322384878209
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "efa1ac32-1afe-415e-8ecf-154baa99bebd",
-      "FullName": "DataOwner11",
-      "DisplayName": "DataOwner11 Display name",
-      "Email": "DataOwner11@mail.com"
+      "StaffUserId": "7484246d-591e-4e82-8065-f6ff89b9f30c",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1974,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "b551fa3e-27cc-404d-be04-2ab2facff9ed",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "77986957"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station12",
-      "Position": "Position12",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.045874121620261166,
-        "Longitude": 0.69695505392595891
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "a347d3ef-df6f-41d9-95e3-5df54aaf849b",
-      "FullName": "DataOwner12",
-      "DisplayName": "DataOwner12 Display name",
-      "Email": "DataOwner12@mail.com"
+      "StaffUserId": "1f985b34-1491-42a5-ad26-fb9284c03bfc",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1922,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 1,
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "0743c0a4-2433-4612-9e13-bb1002ac0983",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "71112547"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station13",
-      "Position": "Position13",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.48605276759995741,
-        "Longitude": 0.94428754409043469
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "61dec575-7311-4ba4-acbb-c20261a58e6f",
-      "FullName": "DataOwner13",
-      "DisplayName": "DataOwner13 Display name",
-      "Email": "DataOwner13@mail.com"
+      "StaffUserId": "acb49321-5652-4f32-ada6-1358cfc95a81",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 2013,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 1,
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "cae92cd7-3e77-4637-8891-e6008f63ab33",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "89463508"
+        "1234567",
+        "2345678"
       ],
-      "DutyStation": "Dutty Station14",
-      "Position": "Position14",
+      "DutyStation": "duty station",
+      "Position": "position",
       "Location": {
-        "Latitude": 0.55373687788552461,
-        "Longitude": 0.37603419990094106
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "293adbea-4c26-4469-98fb-e5a5ee9a4306",
-      "FullName": "DataOwner14",
-      "DisplayName": "DataOwner14 Display name",
-      "Email": "DataOwner14@mail.com"
+      "StaffUserId": "f7c96037-7f5b-4108-9549-d8e6ba2534bd",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "fd6cfdb9-cc70-4052-929b-1eea9fa90e5a",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "DutyStation": "duty station",
+      "Position": "position",
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "e4b954c3-3a20-4bd3-ba14-eef5536791bd",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "271ff99a-a2e4-4d17-91e3-506dd16da870",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "DutyStation": "duty station",
+      "Position": "position",
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "5de8a63a-e04b-4a2d-bb7b-f8437e9bb16f",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "19ea8c0a-782c-4c53-965b-24907833431a",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "DutyStation": "duty station",
+      "Position": "position",
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "2406eeb0-fcd7-40f0-b55e-90be729a4a13",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   }
 ]

--- a/Source/UserManagement/Web/TestData/DataVerifiers.json
+++ b/Source/UserManagement/Web/TestData/DataVerifiers.json
@@ -1,354 +1,254 @@
 [
   {
     "Role": {
-      "BirthYear": 1929,
+      "BirthYear": 1980,
       "Sex": 2,
-      "AssignedNationalSocieties": [
-        "55f764ee-8067-4131-8394-dfedd305d1b0"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "ebef9245-762f-4403-ba6c-f91ddef88b17",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "84720684"
+        "1234567",
+        "2345678"
       ],
       "Location": {
-        "Latitude": 0.87254072533573057,
-        "Longitude": 0.19596063494494215
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "f5e29e2c-a0d1-4ae9-bcd2-aceb2936f921",
-      "FullName": "DataVerifier0",
-      "DisplayName": "DataVerifier0 Display name",
-      "Email": "DataVerifier0@mail.com"
+      "StaffUserId": "e086d929-235b-4ee0-85c6-07491b984f34",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 2010,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
-      ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "23803703"
-      ],
-      "Location": {
-        "Latitude": 0.26281600224916635,
-        "Longitude": 0.25845532410706173
-      },
-      "StaffUserId": "e7e9a818-5552-4816-90ec-317e189ce732",
-      "FullName": "DataVerifier1",
-      "DisplayName": "DataVerifier1 Display name",
-      "Email": "DataVerifier1@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 2016,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "5255406d-89bd-4480-9116-27f3caf45e1d",
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "d296ecda-4005-45bb-b57d-d73df17deb49",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "76722409"
+        "1234567",
+        "2345678"
       ],
       "Location": {
-        "Latitude": 0.00027193641302731652,
-        "Longitude": 0.60436084289306813
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "a6d1d500-6adf-459e-bb3f-87a307bbfba9",
-      "FullName": "DataVerifier2",
-      "DisplayName": "DataVerifier2 Display name",
-      "Email": "DataVerifier2@mail.com"
+      "StaffUserId": "6f29ec46-55d6-416d-8a81-6d0b7c82d1aa",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1949,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7"
-      ],
-      "NationalSociety": "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "14489065"
-      ],
-      "Location": {
-        "Latitude": 0.85014585026080991,
-        "Longitude": 0.61889520502597806
-      },
-      "StaffUserId": "05a05424-f4f7-4233-b163-e77ede52f1b9",
-      "FullName": "DataVerifier3",
-      "DisplayName": "DataVerifier3 Display name",
-      "Email": "DataVerifier3@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 2000,
+      "BirthYear": 1980,
       "Sex": 2,
-      "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
-      ],
-      "NationalSociety": "55f764ee-8067-4131-8394-dfedd305d1b0",
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "2fd64681-4db4-4241-8c11-6e1ed57b1f34",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "97435597"
+        "1234567",
+        "2345678"
       ],
       "Location": {
-        "Latitude": 0.037745776603811315,
-        "Longitude": 0.46338151416898776
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "ceae83e8-7e5f-4755-aaf4-94e26d0d2004",
-      "FullName": "DataVerifier4",
-      "DisplayName": "DataVerifier4 Display name",
-      "Email": "DataVerifier4@mail.com"
+      "StaffUserId": "1c2cd34b-05cc-4a88-b083-d3f79e2f45e6",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1946,
+      "BirthYear": 1980,
       "Sex": 2,
-      "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
-      ],
-      "NationalSociety": "55f764ee-8067-4131-8394-dfedd305d1b0",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "13177663"
-      ],
-      "Location": {
-        "Latitude": 0.551992085553702,
-        "Longitude": 0.67696286769442393
-      },
-      "StaffUserId": "8dea87ba-4448-4b52-b0eb-e797884b3e86",
-      "FullName": "DataVerifier5",
-      "DisplayName": "DataVerifier5 Display name",
-      "Email": "DataVerifier5@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1943,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "37186289"
-      ],
-      "Location": {
-        "Latitude": 0.35831635415475643,
-        "Longitude": 0.595534037610299
-      },
-      "StaffUserId": "99e55537-0b16-445f-979c-427d8c4d2d0c",
-      "FullName": "DataVerifier6",
-      "DisplayName": "DataVerifier6 Display name",
-      "Email": "DataVerifier6@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1920,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "90221205"
-      ],
-      "Location": {
-        "Latitude": 0.45725572596176328,
-        "Longitude": 0.20007359432059973
-      },
-      "StaffUserId": "4635e871-6271-418f-8752-9c069af23eea",
-      "FullName": "DataVerifier7",
-      "DisplayName": "DataVerifier7 Display name",
-      "Email": "DataVerifier7@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1959,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "2d4f9fdc-712d-42f2-99c0-2828bf613cac",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "74061718"
-      ],
-      "Location": {
-        "Latitude": 0.022509583282521731,
-        "Longitude": 0.34514266780817077
-      },
-      "StaffUserId": "2ee868ab-1330-4a26-aa16-d2bdb8f1c12c",
-      "FullName": "DataVerifier8",
-      "DisplayName": "DataVerifier8 Display name",
-      "Email": "DataVerifier8@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1990,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "56b9c71f-f284-4de5-8aa1-6c706f254e4d"
-      ],
-      "NationalSociety": "bf4c9eb4-4660-4054-a61e-0627d1c8434c",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "70748415"
-      ],
-      "Location": {
-        "Latitude": 0.17376820052683736,
-        "Longitude": 0.46777112803783788
-      },
-      "StaffUserId": "d5588a86-d282-44c0-8060-fce2d07515b6",
-      "FullName": "DataVerifier9",
-      "DisplayName": "DataVerifier9 Display name",
-      "Email": "DataVerifier9@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1931,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "5255406d-89bd-4480-9116-27f3caf45e1d",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "21924816"
-      ],
-      "Location": {
-        "Latitude": 0.860649224771489,
-        "Longitude": 0.22062598551652673
-      },
-      "StaffUserId": "fe86969f-11f4-4bce-9369-8d269a223682",
-      "FullName": "DataVerifier10",
-      "DisplayName": "DataVerifier10 Display name",
-      "Email": "DataVerifier10@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1990,
-      "Sex": null,
-      "AssignedNationalSocieties": [
-        "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7"
-      ],
-      "NationalSociety": "55f764ee-8067-4131-8394-dfedd305d1b0",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "65821403"
-      ],
-      "Location": {
-        "Latitude": 0.099292440386159544,
-        "Longitude": 0.35515155520064362
-      },
-      "StaffUserId": "2cf53021-1c0a-4418-b571-014b4aaffc6e",
-      "FullName": "DataVerifier11",
-      "DisplayName": "DataVerifier11 Display name",
-      "Email": "DataVerifier11@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1978,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "56b9c71f-f284-4de5-8aa1-6c706f254e4d",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "15440504"
-      ],
-      "Location": {
-        "Latitude": 0.45598505691438218,
-        "Longitude": 0.11568116262354011
-      },
-      "StaffUserId": "6569cba2-5c67-48a0-a627-9024fc03ab63",
-      "FullName": "DataVerifier12",
-      "DisplayName": "DataVerifier12 Display name",
-      "Email": "DataVerifier12@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1984,
-      "Sex": 1,
-      "AssignedNationalSocieties": [
-        "cec094bd-de50-45da-8ac9-0fc2fadbdf04"
-      ],
-      "NationalSociety": "5255406d-89bd-4480-9116-27f3caf45e1d",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "70934694"
-      ],
-      "Location": {
-        "Latitude": 0.43238300151768283,
-        "Longitude": 0.036654152458838261
-      },
-      "StaffUserId": "28e49ac4-b456-4150-b8db-7a4fac5f7e43",
-      "FullName": "DataVerifier13",
-      "DisplayName": "DataVerifier13 Display name",
-      "Email": "DataVerifier13@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1951,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "55f764ee-8067-4131-8394-dfedd305d1b0"
-      ],
-      "NationalSociety": "2d4f9fdc-712d-42f2-99c0-2828bf613cac",
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "38f5e8aa-7dfd-4270-be10-e9953ed9204e",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "83000545"
+        "1234567",
+        "2345678"
       ],
       "Location": {
-        "Latitude": 0.20953037506413197,
-        "Longitude": 0.74282525328119531
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "e47c164b-8097-42d6-883e-1ff7775b8a89",
-      "FullName": "DataVerifier14",
-      "DisplayName": "DataVerifier14 Display name",
-      "Email": "DataVerifier14@mail.com"
+      "StaffUserId": "e38c59e8-5147-4521-9ead-0ac29c34702e",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1989,
-      "Sex": null,
-      "AssignedNationalSocieties": [
-        "cec094bd-de50-45da-8ac9-0fc2fadbdf04"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "3b459220-40bc-482d-a241-f1358e6ed5b9",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "38955276"
+        "1234567",
+        "2345678"
       ],
       "Location": {
-        "Latitude": 0.0097461529121483457,
-        "Longitude": 0.50928368303425786
+        "Latitude": 45.0,
+        "Longitude": 45.0
       },
-      "StaffUserId": "36f7e6db-19d0-4b36-a687-1af8443601a5",
-      "FullName": "DataVerifier15",
-      "DisplayName": "DataVerifier15 Display name",
-      "Email": "DataVerifier15@mail.com"
+      "StaffUserId": "5320821f-bea2-4201-8778-9413d2f70b18",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "3b1d7d74-f530-4ede-ad15-61c1dd6a00b6",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "f1a57267-86c7-4867-9cfd-12b8d791383e",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "d5a470ef-cbf9-4041-be42-2297146c8c95",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "5943f2ec-2fc3-442b-9482-59a6963b09cf",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "17dce3a2-4411-44aa-b26d-13993bcd5d00",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "672de879-a681-47ce-b0fc-9bf842518082",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "0d47e766-0384-4d45-b95a-5b5035c38d27",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "3de653fb-ac52-46d5-b8a7-5bf273919f32",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "149c77e5-43bf-42b4-bf81-4fd14a20e649",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "9a7cda50-24db-4c3d-866a-28b196043594",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "ca0e189d-db50-4459-a9a2-ddf0f857a0cd",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "7688fb0b-3c6f-4fa6-8e83-d0ffdc2d7b3d",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": 1980,
+      "Sex": 2,
+      "AssignedNationalSocieties": null,
+      "NationalSociety": "70803a3b-7516-4f2d-b900-75862f19d39f",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "Location": {
+        "Latitude": 45.0,
+        "Longitude": 45.0
+      },
+      "StaffUserId": "3fab373a-2ba2-4444-b622-f4bf7d7c76e1",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   }
 ]

--- a/Source/UserManagement/Web/TestData/SystemConfigurators.json
+++ b/Source/UserManagement/Web/TestData/SystemConfigurators.json
@@ -1,236 +1,382 @@
 [
   {
     "Role": {
-      "BirthYear": 2007,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
-      ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "25569310"
-      ],
-      "StaffUserId": "cc56ee8a-dc38-466f-b96d-9adb59aaa2f5",
-      "FullName": "SystemConfigurator0",
-      "DisplayName": "SystemConfigurator0 Display name",
-      "Email": "SystemConfigurator0@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1982,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "56b9c71f-f284-4de5-8aa1-6c706f254e4d"
-      ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "83658751"
-      ],
-      "StaffUserId": "3de50934-d557-4798-a7ad-7b3c2c25132d",
-      "FullName": "SystemConfigurator1",
-      "DisplayName": "SystemConfigurator1 Display name",
-      "Email": "SystemConfigurator1@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1964,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "55f764ee-8067-4131-8394-dfedd305d1b0"
-      ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "89177516"
-      ],
-      "StaffUserId": "9f4b8ca5-fcb0-4a46-9440-983dbee33f21",
-      "FullName": "SystemConfigurator2",
-      "DisplayName": "SystemConfigurator2 Display name",
-      "Email": "SystemConfigurator2@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1966,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "bf4c9eb4-4660-4054-a61e-0627d1c8434c"
+        "8836671d-7bf3-4bdc-97b3-34be61a56a8c",
+        "43edceb3-7e81-49fe-80ca-caabb1744b10"
       ],
-      "NationalSociety": "5255406d-89bd-4480-9116-27f3caf45e1d",
+      "NationalSociety": "cac265fe-4861-4f7a-9ded-e04a9759b203",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "37100326"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "b4c239f1-0122-45c4-a4d0-4413fb0cdc63",
-      "FullName": "SystemConfigurator3",
-      "DisplayName": "SystemConfigurator3 Display name",
-      "Email": "SystemConfigurator3@mail.com"
+      "StaffUserId": "d62086a4-6abb-4e65-9af3-367c79543362",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 2007,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "11585072"
-      ],
-      "StaffUserId": "ec63bdd5-e846-44fd-afd0-16f46cd61ddc",
-      "FullName": "SystemConfigurator4",
-      "DisplayName": "SystemConfigurator4 Display name",
-      "Email": "SystemConfigurator4@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1994,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "56b9c71f-f284-4de5-8aa1-6c706f254e4d"
+        "4903a5de-6351-4521-b296-083c60968d1e",
+        "237fb198-b2f6-454e-b122-329aa4732abf"
       ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
+      "NationalSociety": "39e87bdd-b31d-47c7-8902-e84fef5aeb74",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "18800705"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "032de469-cf5a-402a-b67b-33f3bc126226",
-      "FullName": "SystemConfigurator5",
-      "DisplayName": "SystemConfigurator5 Display name",
-      "Email": "SystemConfigurator5@mail.com"
+      "StaffUserId": "df3fb230-7f74-4c78-a31a-58724dbda7f3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1933,
-      "Sex": 2,
+      "BirthYear": null,
+      "Sex": null,
       "AssignedNationalSocieties": [
-        "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7"
+        "b29df0a6-3034-4526-8047-e44a0eefe364",
+        "9edc745c-0805-4c88-82dd-e369c1b84b10"
       ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "80308795"
-      ],
-      "StaffUserId": "fb8d7a67-5e22-40d6-8ffb-e11a9db3c0c5",
-      "FullName": "SystemConfigurator6",
-      "DisplayName": "SystemConfigurator6 Display name",
-      "Email": "SystemConfigurator6@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1997,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "2d4f9fdc-712d-42f2-99c0-2828bf613cac"
-      ],
-      "NationalSociety": "e32a53b5-ae93-4881-be7c-c289746a70bc",
+      "NationalSociety": "ac0eda97-a969-4443-aff4-a8d5e633bc5f",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "16525746"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "6fe4094c-b1fa-44a7-8088-0486a54063bf",
-      "FullName": "SystemConfigurator7",
-      "DisplayName": "SystemConfigurator7 Display name",
-      "Email": "SystemConfigurator7@mail.com"
+      "StaffUserId": "6af8e2de-7a0e-4293-80b5-5e6d81409664",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1995,
-      "Sex": 2,
-      "AssignedNationalSocieties": [
-        "88ec9b8e-2f9c-49b4-88bb-0e7ee87090ec"
-      ],
-      "NationalSociety": "cec094bd-de50-45da-8ac9-0fc2fadbdf04",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "91282124"
-      ],
-      "StaffUserId": "6ebb049a-196d-43b6-9dff-9bcd61755554",
-      "FullName": "SystemConfigurator8",
-      "DisplayName": "SystemConfigurator8 Display name",
-      "Email": "SystemConfigurator8@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 2014,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "bf4c9eb4-4660-4054-a61e-0627d1c8434c"
+        "a0c12342-8e40-4b70-9164-62cb8b4e0ac0",
+        "877b89f6-7b26-4990-b5bf-a873baa3cef3"
       ],
-      "NationalSociety": "56b9c71f-f284-4de5-8aa1-6c706f254e4d",
-      "PreferredLanguage": 1,
-      "PhoneNumbers": [
-        "19331890"
-      ],
-      "StaffUserId": "0f6fd588-1eb0-433f-a61f-ae932b560d20",
-      "FullName": "SystemConfigurator9",
-      "DisplayName": "SystemConfigurator9 Display name",
-      "Email": "SystemConfigurator9@mail.com"
-    }
-  },
-  {
-    "Role": {
-      "BirthYear": 1966,
-      "Sex": null,
-      "AssignedNationalSocieties": [
-        "5255406d-89bd-4480-9116-27f3caf45e1d"
-      ],
-      "NationalSociety": "dcc501ec-e5ae-4ecd-bbb4-8b26d050f1e7",
+      "NationalSociety": "bf2a62de-3277-44d4-8b85-6d64c74c1432",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "93528897"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "3746c75a-dc2c-4e82-ae38-9f88031dfa99",
-      "FullName": "SystemConfigurator10",
-      "DisplayName": "SystemConfigurator10 Display name",
-      "Email": "SystemConfigurator10@mail.com"
+      "StaffUserId": "ce3d06c5-d1bd-432d-a6a0-fa8b10295ad6",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 2003,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "e32a53b5-ae93-4881-be7c-c289746a70bc"
+        "d4f79cc9-8f3d-450a-a29e-178dfe4a9207",
+        "b79dd118-7878-4cf4-9ff8-c85c1601dd59"
       ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
+      "NationalSociety": "68aa2656-4336-437c-8631-059f5eb67e9a",
       "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "81384044"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "2222e56b-cd18-475d-b421-c6cf4c2f1f67",
-      "FullName": "SystemConfigurator11",
-      "DisplayName": "SystemConfigurator11 Display name",
-      "Email": "SystemConfigurator11@mail.com"
+      "StaffUserId": "83fc69c5-24a3-4322-a19c-9d62981ebc3a",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   },
   {
     "Role": {
-      "BirthYear": 1992,
+      "BirthYear": null,
       "Sex": null,
       "AssignedNationalSocieties": [
-        "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7"
+        "a8f0332e-cfb3-409d-9d54-9a48984d7609",
+        "f4718f3a-72db-45cd-93fe-1efc30a8b126"
       ],
-      "NationalSociety": "4c73fbfc-0ce9-4eab-abb5-b9740498cfe7",
-      "PreferredLanguage": 1,
+      "NationalSociety": "893b7358-28b5-4f8b-be5c-1f053c4f0165",
+      "PreferredLanguage": 0,
       "PhoneNumbers": [
-        "12072107"
+        "1234567",
+        "2345678"
       ],
-      "StaffUserId": "3994c173-32d4-403d-88c9-3690244f899d",
-      "FullName": "SystemConfigurator12",
-      "DisplayName": "SystemConfigurator12 Display name",
-      "Email": "SystemConfigurator12@mail.com"
+      "StaffUserId": "8d5fe4e7-fca4-41b5-8daf-c664a52a3ac3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "4ed94d4a-2aaf-411c-a258-2dac91ea5501",
+        "4ded43f3-8629-4c53-8e17-5dadeebc4682"
+      ],
+      "NationalSociety": "7546fedb-1500-45df-bad7-6a39f05e67ca",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "c5953da4-3ab4-41bd-b12b-331f9e6a75ac",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "42f97d6a-b3f8-457e-af82-4a4ad9cb543d",
+        "3e69108d-71a9-429d-897f-61384c3596b6"
+      ],
+      "NationalSociety": "be57b107-5e93-4e60-affe-39485de6e869",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "fa2bfb76-ce9b-40b9-8bab-0c0d8e28230f",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "f9206c54-60a1-4b76-a0ca-da6e8ec30b76",
+        "42edd147-7151-431a-a358-e61a18b5409c"
+      ],
+      "NationalSociety": "fd39d72b-baa1-42df-a923-501608bd9086",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "0c5e4c7c-374d-4cab-9a8e-afed546c7ac5",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "1ee8452a-4fc9-47d6-a0f9-526756a98fb7",
+        "c43c0bc3-6a72-445d-b9d5-2f82ad6ebca7"
+      ],
+      "NationalSociety": "83a1a778-2fd7-4e36-b3e5-a9516032c7ef",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "1573d985-e38d-4583-b656-4c8ce5d3b5cf",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "27c06edd-28a3-4d8c-b141-c085c644d698",
+        "f6991905-44ac-4f2d-9960-085456da348e"
+      ],
+      "NationalSociety": "8098e214-f8f7-4e31-b99e-e566f2646956",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "800c41d5-c611-453f-80ef-f8380d2c49a9",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "daa2582f-ad46-457a-9fa8-5890d341318e",
+        "c2742c02-038d-4f99-83d4-e4ef6831a602"
+      ],
+      "NationalSociety": "5320f4e6-2bd7-4515-90db-c30bfc1f9952",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "f850fd03-e3c9-4716-b3c7-e4d39221dfde",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "33120911-e990-4a4f-928f-1a02cda02b51",
+        "bcab6475-4f25-4c09-b972-87b4ac59e657"
+      ],
+      "NationalSociety": "2e02ce1c-a07c-4aa2-b61b-1d1f0b6f1bbc",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "04a134a7-b792-44f7-9103-a78dc016e4e3",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "4cf94a35-6b1f-43ee-9166-ce38ed2f6ccc",
+        "bde87ca0-95d7-47e2-860f-39899c1146af"
+      ],
+      "NationalSociety": "3cd044ac-4a93-49ca-9e91-20521ffedd96",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "82360ae5-7f01-4ac4-8ceb-2680542a199c",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "e91e3390-aca1-4ebe-b171-f721b9af033c",
+        "f26a865d-7271-4d7d-b502-ea5b14659c81"
+      ],
+      "NationalSociety": "01fd8aae-298c-4077-aed9-3376e34cc19d",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "35330d5a-d56c-4fdb-835a-d65941cb34a7",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "e1ba99df-c06e-4073-9ea2-523f70a32754",
+        "66eceb23-c7b1-4f03-86ca-383d1ce322a1"
+      ],
+      "NationalSociety": "b15b0ddf-f0ec-441f-a1b7-734c24adf54e",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "4458e05e-949e-496a-a2e7-20eef693dd2a",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "2c5afedb-56f3-495a-bcc5-2ffd872462b8",
+        "89c35544-6ac5-463c-a2eb-f98452af17de"
+      ],
+      "NationalSociety": "e082e484-37d3-4a4d-a6a6-edb84640e293",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "4e76ce4a-7f64-4e4c-b2e4-e34f08c6602c",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "fb0cfda0-5f7d-4ec0-898b-472319004883",
+        "8dbb88f8-c74d-43b5-8986-9affadb1a967"
+      ],
+      "NationalSociety": "59193226-58c6-4888-ac16-49275b9a9b77",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "ae1e13fd-e008-4aab-a60f-74dbcfd15acc",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
+    }
+  },
+  {
+    "Role": {
+      "BirthYear": null,
+      "Sex": null,
+      "AssignedNationalSocieties": [
+        "c662ccb0-b5ff-4772-98fa-caa965b5106a",
+        "17afdb48-7c06-42cc-a8e3-def788c690a9"
+      ],
+      "NationalSociety": "0d7cbe2a-1d81-4154-9745-f68431dfc76f",
+      "PreferredLanguage": 0,
+      "PhoneNumbers": [
+        "1234567",
+        "2345678"
+      ],
+      "StaffUserId": "bbbeb6ee-0050-48f7-b043-6899d5f17826",
+      "FullName": "Our New User",
+      "DisplayName": "Joe",
+      "Email": "user@redcross.no"
     }
   }
 ]

--- a/Source/UserManagement/Web/TestData/TestDataGenerator.cs
+++ b/Source/UserManagement/Web/TestData/TestDataGenerator.cs
@@ -7,6 +7,7 @@ using Concepts;
 using Domain.DataCollector.Registering;
 using Domain.StaffUser.Registering;
 using Newtonsoft.Json;
+using specs = Domain.Specs;
 
 namespace Web.TestData
 {
@@ -43,19 +44,16 @@ namespace Web.TestData
 
         public static void GenerateCorrectRegisterDataCollectorCommands()
         {
-            var data = names.Select(name => new RegisterDataCollector
-                {
-                    DisplayName = name.Replace(' ', '_') + "DISP",
-                    FullName = name,
-                    GpsLocation = new Location(rng.NextDouble(), rng.NextDouble()),
-                    PhoneNumbers = new List<string> {rng.Next(00000000, 99999999).ToString()},
-                    NationalSociety = Guid.NewGuid(),
-                    PreferredLanguage = (Language)languageVals.GetValue(rng.Next(languageVals.Length)),
-                    Sex = (Sex)sexVals.GetValue(rng.Next(sexVals.Length)),
-                    YearOfBirth = rng.Next(1920, 2018)
-                }).ToList();
+           
+            var data = new List<RegisterDataCollector>();
 
-
+            foreach (var name in names)
+            {
+                var dataCollector = specs.DataCollector.when_registering_a_data_collector.given.a_command_builder.get_valid_command();
+                dataCollector.DisplayName = name + "_Disp";
+                dataCollector.FullName = name;
+                data.Add(dataCollector);
+            }
             using (var file = File.CreateText("./TestData/DataCollectors.json"))
             {
                 file.WriteLine(JsonConvert.SerializeObject(data, Formatting.Indented));   
@@ -68,14 +66,13 @@ namespace Web.TestData
             const int numRegistrations = 100;
 
             var roleVals = Enum.GetValues(typeof(_Role));
-
-
-            List<RegisterNewAdminUser> admins = new List<RegisterNewAdminUser>();
-            List<RegisterNewStaffDataConsumer> dataConsumers = new List<RegisterNewStaffDataConsumer>();
-            List<RegisterNewDataCoordinator> dataCoordinator = new List<RegisterNewDataCoordinator>();
-            List<RegisterNewDataOwner> dataOwners = new List<RegisterNewDataOwner>();
-            List<RegisterNewStaffDataVerifier> dataVerifiers = new List<RegisterNewStaffDataVerifier>();
-            List<RegisterNewSystemConfigurator> systemConfigurators = new List<RegisterNewSystemConfigurator>();
+            
+            var admins = new List<RegisterNewAdminUser>();
+            var dataConsumers = new List<RegisterNewStaffDataConsumer>();
+            var dataCoordinator = new List<RegisterNewDataCoordinator>();
+            var dataOwners = new List<RegisterNewDataOwner>();
+            var dataVerifiers = new List<RegisterNewStaffDataVerifier>();
+            var systemConfigurators = new List<RegisterNewSystemConfigurator>();
 
 
             for (var i = 0; i < numRegistrations; i++)
@@ -87,22 +84,22 @@ namespace Web.TestData
                 switch (role)
                 {
                     case _Role.Admin:
-                        admins.Add(CreateRegisterNewAdminUserCommand());
+                        admins.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewAdminUser>());
                         break;
                     case _Role.DataConsumer:
-                        dataConsumers.Add(CreateRegisterNewDataConsumerCommand());
+                        dataConsumers.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewStaffDataConsumer>());
                         break;
                     case _Role.DataCoordinator:
-                        dataCoordinator.Add(CreateRegisterNewDataCoordinatorCommand());
+                        dataCoordinator.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewDataCoordinator>());
                         break;
                     case _Role.DataOwner:
-                        dataOwners.Add(CreateRegisterNewDataOwnerCommand());
+                        dataOwners.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewDataOwner>());
                         break;
                     case _Role.DataVerifier:
-                        dataVerifiers.Add(CreateRegisterNewStaffDataVerifierCommand());
+                        dataVerifiers.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewStaffDataVerifier>());
                         break;
                     case _Role.SystemCoordinator:
-                        systemConfigurators.Add(CreateRegisterNewSystemConfiguratorCommand());
+                        systemConfigurators.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewSystemConfigurator>());
                         break;
                 }
             }
@@ -130,151 +127,6 @@ namespace Web.TestData
             {
                 file.WriteLine(JsonConvert.SerializeObject(systemConfigurators, Formatting.Indented));
             }
-
-        }
-        private static RegisterNewAdminUser CreateRegisterNewAdminUserCommand()
-        {
-            var name = "Admin" + numAdmins;
-            var result = new RegisterNewAdminUser()
-            {
-                Role =
-                {
-                    FullName = name,
-                    DisplayName = name + "_Display_Name",
-                    Email = name + "@mail.com",
-                }
-            };
-            numAdmins++;
-
-            return result;
-        }
-        private static RegisterNewStaffDataConsumer CreateRegisterNewDataConsumerCommand()
-        {
-            var name = "DataConsumer" + numDataConsumers;
-            var result = new RegisterNewStaffDataConsumer
-            {
-                Role =
-                {
-                    FullName = name,
-                    DisplayName = name + " Display name",
-                    Email = name + "@mail.com",
-
-                    Location = new Location(rng.NextDouble(), rng.NextDouble()),
-                    BirthYear = rng.Next(1920, 2017),
-                    NationalSociety = nationalSocieties[rng.Next(nationalSocieties.Length)],
-                    PreferredLanguage = (Language)languageVals.GetValue(rng.Next(languageVals.Length)),
-                    Sex = (rng.NextDouble() < 0.8)? (Sex)sexVals.GetValue(rng.Next(sexVals.Length)) : (Sex?)null,
-                    StaffUserId = Guid.NewGuid()
-                }
-            };
-            numDataConsumers++;
-
-            return result;
-        }
-        private static RegisterNewDataCoordinator CreateRegisterNewDataCoordinatorCommand()
-        {
-            var name = "DataCoordinator" + numDataCoordinators;
-            var result = new RegisterNewDataCoordinator()
-            {
-                Role =
-                {
-                    FullName = name,
-                    DisplayName = name + " Display name",
-                    Email = name + "@mail.com",
-                    
-                    BirthYear = rng.Next(1920, 2017),
-                    
-                    NationalSociety = nationalSocieties[rng.Next(nationalSocieties.Length)],
-                    PreferredLanguage = (Language)languageVals.GetValue(rng.Next(languageVals.Length)),
-                    Sex = (rng.NextDouble() < 0.8)? (Sex)sexVals.GetValue(rng.Next(sexVals.Length)) : (Sex?)null,
-                    StaffUserId = Guid.NewGuid(),
-                    PhoneNumbers = new List<string> { rng.Next(00000000, 99999999).ToString() },
-                    AssignedNationalSocieties = new List<Guid> { nationalSocieties[rng.Next(nationalSocieties.Length)] }
-                }
-            };
-            numDataCoordinators++;
-
-            return result;
-        }
-        private static RegisterNewDataOwner CreateRegisterNewDataOwnerCommand()
-        {
-            var name = "DataOwner" + numDataOwners;
-            
-            var result = new RegisterNewDataOwner()
-            {
-                Role = {
-                    FullName = name,
-                    DisplayName = name + " Display name",
-                    Email = name + "@mail.com",
-
-                    BirthYear = rng.Next(1920, 2017),
-
-                    NationalSociety = nationalSocieties[rng.Next(nationalSocieties.Length)],
-                    PreferredLanguage = (Language)languageVals.GetValue(rng.Next(languageVals.Length)),
-                    Sex = (rng.NextDouble() < 0.8)? (Sex)sexVals.GetValue(rng.Next(sexVals.Length)) : (Sex?)null,
-                    StaffUserId = Guid.NewGuid(),
-                    PhoneNumbers = new List<string> { rng.Next(00000000, 99999999).ToString() },
-                    AssignedNationalSocieties = new List<Guid> { nationalSocieties[rng.Next(nationalSocieties.Length)] },
-                    Location = new Location(rng.NextDouble(), rng.NextDouble()),
-                    DutyStation = "Dutty Station" + numDataOwners,
-                    Position = "Position" + numDataOwners
-                }
-            };
-            numDataOwners++;
-
-            return result;
-        }
-        private static RegisterNewStaffDataVerifier CreateRegisterNewStaffDataVerifierCommand()
-        {
-            var name = "DataVerifier" + numDataVerifiers;
-
-            var result = new RegisterNewStaffDataVerifier()
-            {
-                Role =
-                {
-                    FullName = name,
-                    DisplayName = name + " Display name",
-                    Email = name + "@mail.com",
-
-                    BirthYear = rng.Next(1920, 2017),
-
-                    NationalSociety = nationalSocieties[rng.Next(nationalSocieties.Length)],
-                    PreferredLanguage = (Language)languageVals.GetValue(rng.Next(languageVals.Length)),
-                    Sex = (rng.NextDouble() < 0.8)? (Sex)sexVals.GetValue(rng.Next(sexVals.Length)) : (Sex?)null,
-                    StaffUserId = Guid.NewGuid(),
-                    PhoneNumbers = new List<string> { rng.Next(00000000, 99999999).ToString() },
-                    AssignedNationalSocieties = new List<Guid> { nationalSocieties[rng.Next(nationalSocieties.Length)] },
-                    Location = new Location(rng.NextDouble(), rng.NextDouble())
-                }
-            };
-            numDataVerifiers++;
-
-            return result;
-        }
-        private static RegisterNewSystemConfigurator CreateRegisterNewSystemConfiguratorCommand()
-        {
-            var name = "SystemConfigurator" + numSystemConfigurators;
-            var result = new RegisterNewSystemConfigurator()
-            {
-                Role =
-                {
-                    FullName = name,
-                    DisplayName = name + " Display name",
-                    Email = name + "@mail.com",
-
-                    BirthYear = rng.Next(1920, 2017),
-
-                    NationalSociety = nationalSocieties[rng.Next(nationalSocieties.Length)],
-                    PreferredLanguage = (Language)languageVals.GetValue(rng.Next(languageVals.Length)),
-                    Sex = (rng.NextDouble() < 0.8)? (Sex)sexVals.GetValue(rng.Next(sexVals.Length)) : (Sex?)null,
-                    StaffUserId = Guid.NewGuid(),
-                    PhoneNumbers = new List<string> { rng.Next(00000000, 99999999).ToString() },
-                    AssignedNationalSocieties = new List<Guid> { nationalSocieties[rng.Next(nationalSocieties.Length)] }
-                }
-            };
-            numSystemConfigurators++;
-
-            return result;
         }
     }
 }

--- a/Source/UserManagement/Web/TestData/TestDataGenerator.cs
+++ b/Source/UserManagement/Web/TestData/TestDataGenerator.cs
@@ -1,41 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using Concepts;
-using Domain.DataCollector.Registering;
-using Domain.StaffUser.Registering;
 using Newtonsoft.Json;
-using specs = Domain.Specs;
 
 namespace Web.TestData
 {
     public static class TestDataGenerator
     {
-        private static int numAdmins = 0;
-        private static int numDataConsumers = 0;
-        private static int numDataCoordinators = 0;
-        private static int numDataOwners = 0;
-        private static int numDataVerifiers = 0;
-        private static int numSystemConfigurators = 0;
-
-        private static Array languageVals = Enum.GetValues(typeof(Language));
-        private static Array sexVals = Enum.GetValues(typeof(Sex));
-
-        private static readonly Random rng = new Random();
-
-        private static readonly string[] names =
-        {
-            "Abraham Watson",
-            "Vanessa Wallace",
-            "Billie Mclaughlin"
-        };
-
-        private static readonly Guid[] nationalSocieties =
-            Enumerable.Range(0, 10).Select(x => Guid.NewGuid()).ToArray();
-
-
         public static void GenerateAllTestData()
         {
             GenerateCorrectRegisterDataCollectorCommands();
@@ -45,88 +17,88 @@ namespace Web.TestData
         public static void GenerateCorrectRegisterDataCollectorCommands()
         {
            
-            var data = new List<RegisterDataCollector>();
+            //var data = new List<RegisterDataCollector>();
 
-            foreach (var name in names)
-            {
-                var dataCollector = specs.DataCollector.when_registering_a_data_collector.given.a_command_builder.get_valid_command();
-                dataCollector.DisplayName = name + "_Disp";
-                dataCollector.FullName = name;
-                data.Add(dataCollector);
-            }
-            using (var file = File.CreateText("./TestData/DataCollectors.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(data, Formatting.Indented));   
-            }
+            //foreach (var name in names)
+            //{
+            //    var dataCollector = specs.DataCollector.when_registering_a_data_collector.given.a_command_builder.get_valid_command();
+            //    dataCollector.DisplayName = name + "_Disp";
+            //    dataCollector.FullName = name;
+            //    data.Add(dataCollector);
+            //}
+            //using (var file = File.CreateText("./TestData/DataCollectors.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(data, Formatting.Indented));   
+            //}
         }
 
         public static void GenerateCorrectRegisterStaffUserCommands()
         {
-            StringBuilder sb = new StringBuilder();
-            const int numRegistrations = 100;
+            //StringBuilder sb = new StringBuilder();
+            //const int numRegistrations = 100;
 
-            var roleVals = Enum.GetValues(typeof(_Role));
+            //var roleVals = Enum.GetValues(typeof(_Role));
             
-            var admins = new List<RegisterNewAdminUser>();
-            var dataConsumers = new List<RegisterNewStaffDataConsumer>();
-            var dataCoordinator = new List<RegisterNewDataCoordinator>();
-            var dataOwners = new List<RegisterNewDataOwner>();
-            var dataVerifiers = new List<RegisterNewStaffDataVerifier>();
-            var systemConfigurators = new List<RegisterNewSystemConfigurator>();
+            //var admins = new List<RegisterNewAdminUser>();
+            //var dataConsumers = new List<RegisterNewStaffDataConsumer>();
+            //var dataCoordinator = new List<RegisterNewDataCoordinator>();
+            //var dataOwners = new List<RegisterNewDataOwner>();
+            //var dataVerifiers = new List<RegisterNewStaffDataVerifier>();
+            //var systemConfigurators = new List<RegisterNewSystemConfigurator>();
 
 
-            for (var i = 0; i < numRegistrations; i++)
-            {
-                //TODO: Should we depend on _Role? 
-                //TODO: Maybe create another class to create commands dynamically, like in Domain.Specs
-                _Role role = (_Role)roleVals.GetValue(rng.Next(roleVals.Length));
+            //for (var i = 0; i < numRegistrations; i++)
+            //{
+            //    //TODO: Should we depend on _Role? 
+            //    //TODO: Maybe create another class to create commands dynamically, like in Domain.Specs
+            //    _Role role = (_Role)roleVals.GetValue(rng.Next(roleVals.Length));
 
-                switch (role)
-                {
-                    case _Role.Admin:
-                        admins.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewAdminUser>());
-                        break;
-                    case _Role.DataConsumer:
-                        dataConsumers.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewStaffDataConsumer>());
-                        break;
-                    case _Role.DataCoordinator:
-                        dataCoordinator.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewDataCoordinator>());
-                        break;
-                    case _Role.DataOwner:
-                        dataOwners.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewDataOwner>());
-                        break;
-                    case _Role.DataVerifier:
-                        dataVerifiers.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewStaffDataVerifier>());
-                        break;
-                    case _Role.SystemCoordinator:
-                        systemConfigurators.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewSystemConfigurator>());
-                        break;
-                }
-            }
-            using (var file = File.CreateText("./TestData/Admins.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(admins, Formatting.Indented ));
-            }
-            using (var file = File.CreateText("./TestData/DataConsumers.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(dataConsumers, Formatting.Indented));
-            }
-            using (var file = File.CreateText("./TestData/DataCoordinators.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(dataCoordinator, Formatting.Indented));
-            }
-            using (var file = File.CreateText("./TestData/DataOwners.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(dataOwners, Formatting.Indented));
-            }
-            using (var file = File.CreateText("./TestData/DataVerifiers.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(dataVerifiers, Formatting.Indented));
-            }
-            using (var file = File.CreateText("./TestData/SystemConfigurators.json"))
-            {
-                file.WriteLine(JsonConvert.SerializeObject(systemConfigurators, Formatting.Indented));
-            }
+            //    switch (role)
+            //    {
+            //        case _Role.Admin:
+            //            admins.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewAdminUser>());
+            //            break;
+            //        case _Role.DataConsumer:
+            //            dataConsumers.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewStaffDataConsumer>());
+            //            break;
+            //        case _Role.DataCoordinator:
+            //            dataCoordinator.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewDataCoordinator>());
+            //            break;
+            //        case _Role.DataOwner:
+            //            dataOwners.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewDataOwner>());
+            //            break;
+            //        case _Role.DataVerifier:
+            //            dataVerifiers.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewStaffDataVerifier>());
+            //            break;
+            //        case _Role.SystemCoordinator:
+            //            systemConfigurators.Add(specs.StaffUser.Registering.given.commands.build_valid_instance<RegisterNewSystemConfigurator>());
+            //            break;
+            //    }
+            //}
+            //using (var file = File.CreateText("./TestData/Admins.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(admins, Formatting.Indented ));
+            //}
+            //using (var file = File.CreateText("./TestData/DataConsumers.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(dataConsumers, Formatting.Indented));
+            //}
+            //using (var file = File.CreateText("./TestData/DataCoordinators.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(dataCoordinator, Formatting.Indented));
+            //}
+            //using (var file = File.CreateText("./TestData/DataOwners.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(dataOwners, Formatting.Indented));
+            //}
+            //using (var file = File.CreateText("./TestData/DataVerifiers.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(dataVerifiers, Formatting.Indented));
+            //}
+            //using (var file = File.CreateText("./TestData/SystemConfigurators.json"))
+            //{
+            //    file.WriteLine(JsonConvert.SerializeObject(systemConfigurators, Formatting.Indented));
+            //}
         }
     }
 }

--- a/Source/UserManagement/Web/Web.csproj
+++ b/Source/UserManagement/Web/Web.csproj
@@ -18,6 +18,5 @@
     <ProjectReference Include="..\Events\Events.csproj" />
     <ProjectReference Include="..\Read\Read.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
-    <ProjectReference Include="..\Domain.Specs\Domain.Specs.csproj" />
   </ItemGroup>
 </Project>

--- a/Source/UserManagement/Web/Web.csproj
+++ b/Source/UserManagement/Web/Web.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\Events\Events.csproj" />
     <ProjectReference Include="..\Read\Read.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Domain.Specs\Domain.Specs.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Should close down issues: #479, #500 

Made the Web project dependent on Domain.Specs, the though is that the testdata generator should have access to the specs of the domain to be able to always generate correct data according to the specs.

Also, should methods in the Read collections really throw exception, for example when a user with a specific ID is not found?