### PR TITLE
Remove yarn install from frontend build

### DIFF
--- a/Source/Admin/Web.Angular/Dockerfile
+++ b/Source/Admin/Web.Angular/Dockerfile
@@ -1,7 +1,6 @@
 # Build the static content part
 FROM node:latest AS angular-build
 WORKDIR /src
-RUN ["npm", "install", "-g", "yarn"]
 RUN ["yarn","global", "add", "typescript"]
 RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src

--- a/Source/UserManagement/Web.Angular/Dockerfile
+++ b/Source/UserManagement/Web.Angular/Dockerfile
@@ -1,7 +1,6 @@
 # Build the static content part
 FROM node:latest AS angular-build
 WORKDIR /src
-RUN ["npm", "install", "-g", "yarn"]
 RUN ["yarn","global", "add", "typescript"]
 RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src

--- a/Source/VolunteerReporting/Web.Angular/Dockerfile
+++ b/Source/VolunteerReporting/Web.Angular/Dockerfile
@@ -1,7 +1,6 @@
 # Build the static content part
 FROM node:latest AS angular-build
 WORKDIR /src
-RUN ["npm", "install", "-g", "yarn"]
 RUN ["yarn","global", "add", "typescript"]
 RUN ["yarn","global", "add", "@angular/cli@latest"]
 COPY . /src


### PR DESCRIPTION
The 'npm install -g yarn' was failing intermittently. Further,
installing yarn with npm is discouraged, and since node:latest comes
with yarn preinstalled, it is not necessary.

Fixes #574 (at least for my builds)