### PR TITLE
Update deployment to use redcrossredcrescent Docker Hub repo

### DIFF
--- a/Build/docker_cloud/pre_push
+++ b/Build/docker_cloud/pre_push
@@ -4,7 +4,6 @@
 source $REPO_ROOT/Build/docker_cloud/new_build_num
 
 # Short commit sha
-SOURCE_COMMIT=8b72df9caf0e80678f442fb52d7b06a5902e8a5b
 SHORT_COMMIT=$(echo $SOURCE_COMMIT | cut -c -7)
 
 # New image name, repo:version-build.commit

--- a/Deploy/values.yaml
+++ b/Deploy/values.yaml
@@ -3,34 +3,34 @@ services:
     # are available. But they need an inital version to be deployable.
     admin:
         frontend:
-            image: jakobho/cbs-admin-frontend
+            image: redcrossredcrescent/cbs-admin-frontend
             version: 0.0.1-0.8b72df9
             service: cbs-admin-frontend-service
             path: /
         backend:
-            image: jakobho/cbs-admin-backend
+            image: redcrossredcrescent/cbs-admin-backend
             version: 0.0.1-0.8b72df9
             path: /adminbackend
             service: cbs-admin-backend-service
     usermanagement:
         frontend:
-            image: jakobho/cbs-usermgmt-frontend
+            image: redcrossredcrescent/cbs-usermgmt-frontend
             version: 0.0.1-0.8b72df9
             service: cbs-usermanagement-frontend-service
             path: /users
         backend:
-            image: jakobho/cbs-usermgmt-backend
+            image: redcrossredcrescent/cbs-usermgmt-backend
             version: 0.0.1-0.8b72df9
             path: /usermanagementbackend
             service: cbs-usermanagement-backend-service
     volunteerreporting:
         frontend:
-            image: jakobho/cbs-vr-frontend
+            image: redcrossredcrescent/cbs-vr-frontend
             version: 0.0.1-0.8b72df9
             service: cbs-volunteerreporting-frontend-service
             path: /reporting
         backend:
-            image: jakobho/cbs-vr-backend
+            image: redcrossredcrescent/cbs-vr-backend
             version: 0.0.1-0.8b72df9
             path: /volunteerreportingbackend
             service: cbs-volunteerreporting-backend-service


### PR DESCRIPTION
Updated the Helm chart to use the new official Docker Hub repository
that is now building images on push to IFRCgo/cbs.

Also fixed a small brainlapse I had during development of the Docker Hub
scripts, so that all images would be tagged with a fixed commit id.