### PR TITLE
Should solve #595 and #596

### DIFF
--- a/Source/VolunteerReporting/Read/CaseReports/CaseReportEventProcessors.cs
+++ b/Source/VolunteerReporting/Read/CaseReports/CaseReportEventProcessors.cs
@@ -19,7 +19,7 @@ namespace Read.CaseReports
             _caseReportsFromUnknownDataCollectors = caseReportsFromUnknownDataCollectors;
         }
         
-        public async Task Process(CaseReportReceived @event)
+        public void Process(CaseReportReceived @event)
         {
             // Save CaseReport in the CaseReports DB
             var caseReport = new CaseReport(@event.CaseReportId)
@@ -33,9 +33,9 @@ namespace Read.CaseReports
                 Location = new Location(@event.Latitude, @event.Longitude),
                 Timestamp = @event.Timestamp
             };
-            await _caseReports.Save(caseReport);
+            _caseReports.Save(caseReport);
         }
-        public async Task Process(CaseReportFromUnknownDataCollectorReceived @event)
+        public void Process(CaseReportFromUnknownDataCollectorReceived @event)
         {
             // Save CaseReport in the CaseReportsFromUnkown... DB
             var caseReport = new CaseReportFromUnknownDataCollector(@event.CaseReportId)
@@ -48,7 +48,7 @@ namespace Read.CaseReports
                 NumberOfMalesAgedOver4 = @event.NumberOfMalesAgedOver4,
                 Timestamp = @event.Timestamp
             };
-            await _caseReportsFromUnknownDataCollectors.Save(caseReport);
+            _caseReportsFromUnknownDataCollectors.Save(caseReport);
         }   
         
         public async Task Process(CaseReportIdentified @event)

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportForListing.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportForListing.cs
@@ -1,10 +1,12 @@
 using Concepts;
 using System;
+using System.Collections.Generic;
 
 namespace Read.CaseReportsForListing
 {
     public class CaseReportForListing
     {
+        //TODO: Comment woksin: This whole Read project for casereports needs a rework like what I did for UserManagement
         public Guid Id { get; private set; }
         public CaseReportStatus Status { get; internal set; }
         public DataCollectorId DataCollectorId { get; internal set; }
@@ -18,7 +20,12 @@ namespace Read.CaseReportsForListing
         public int NumberOfMalesAges0To4 { get; internal set; } 
         public DateTimeOffset Timestamp { get; internal set; }
         public Location Location { get; internal set; }
-        
+
+        public string Origin { get; internal set; }
+
+        public IEnumerable<string> ParsingErrorMessage { get; internal set; }
+
+
         public CaseReportForListing(Guid id)
         {
             Id = id;

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportForListingEventProcessor.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportForListingEventProcessor.cs
@@ -38,7 +38,8 @@ namespace Read.CaseReportsForListing
                 NumberOfMalesAges0To4 = @event.NumberOfMalesAges0To4,
                 NumberOfMalesAgedOver4 = @event.NumberOfMalesAgedOver4,
                 Location = new Location(@event.Latitude, @event.Longitude),
-                Timestamp = @event.Timestamp
+                Timestamp = @event.Timestamp,
+                Origin = @event.Origin
             };
             await _caseReports.Save(caseReport);
         }
@@ -57,13 +58,15 @@ namespace Read.CaseReportsForListing
                 NumberOfFemalesAgedOver4 = @event.NumberOfFemalesAgedOver4,
                 NumberOfMalesAges0To4 = @event.NumberOfMalesAges0To4,
                 NumberOfMalesAgedOver4 = @event.NumberOfMalesAgedOver4,
-                Timestamp = @event.Timestamp
+                Timestamp = @event.Timestamp,
+                Origin = @event.Origin
             };
             await _caseReports.Save(caseReport);
         }
 
         public async Task Process(CaseReportIdentified @event)
         {
+            //TODO: Is this correct?
             await _caseReports.Remove(@event.CaseReportId);
         }
 
@@ -76,7 +79,9 @@ namespace Read.CaseReportsForListing
                 DataCollectorId = @event.DataCollectorId,
                 DataCollectorDisplayName = dataCollector.DisplayName,
                 Message = @event.Message,
-                Timestamp = @event.Timestamp
+                Timestamp = @event.Timestamp,
+                Origin = @event.Origin,
+                ParsingErrorMessage = @event.ErrorMessages
             };
             await _caseReports.Save(caseReport);
         }
@@ -87,7 +92,9 @@ namespace Read.CaseReportsForListing
             {
                 Status = CaseReportStatus.TextMessageParsingErrorAndUnknownDataCollector,
                 Message = @event.Message,
-                Timestamp = @event.Timestamp
+                Timestamp = @event.Timestamp,
+                Origin = @event.Origin,
+                ParsingErrorMessage = @event.ErrorMessages
             };
             await _caseReports.Save(caseReport);
         }

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportForListingEventProcessor.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportForListingEventProcessor.cs
@@ -22,7 +22,7 @@ namespace Read.CaseReportsForListing
             _dataCollectors = dataCollectors;
             _healthRisks = healthRisks;
         }
-        public async Task Process(CaseReportReceived @event)
+        public void Process(CaseReportReceived @event)
         {
             var dataCollector = _dataCollectors.GetById(@event.DataCollectorId);
             var healthRisk = _healthRisks.GetById(@event.HealthRiskId);
@@ -41,12 +41,12 @@ namespace Read.CaseReportsForListing
                 Timestamp = @event.Timestamp,
                 Origin = @event.Origin
             };
-            await _caseReports.Save(caseReport);
+             _caseReports.Save(caseReport);
         }
 
         //QUESTION: Should we also listen to datacollector and health risk changes to update names? Or is there a better way to do this?
 
-        public async Task Process(CaseReportFromUnknownDataCollectorReceived @event)
+        public void Process(CaseReportFromUnknownDataCollectorReceived @event)
         {            
             var healthRisk = _healthRisks.GetById(@event.HealthRiskId);
             var caseReport = new CaseReportForListing(@event.CaseReportId)
@@ -61,7 +61,7 @@ namespace Read.CaseReportsForListing
                 Timestamp = @event.Timestamp,
                 Origin = @event.Origin
             };
-            await _caseReports.Save(caseReport);
+             _caseReports.Save(caseReport);
         }
 
         public async Task Process(CaseReportIdentified @event)
@@ -70,7 +70,7 @@ namespace Read.CaseReportsForListing
             await _caseReports.Remove(@event.CaseReportId);
         }
 
-        public async Task Process(InvalidReportReceived @event)
+        public void Process(InvalidReportReceived @event)
         {
             var dataCollector = _dataCollectors.GetById(@event.DataCollectorId);
             var caseReport = new CaseReportForListing(@event.CaseReportId)
@@ -83,10 +83,10 @@ namespace Read.CaseReportsForListing
                 Origin = @event.Origin,
                 ParsingErrorMessage = @event.ErrorMessages
             };
-            await _caseReports.Save(caseReport);
+            _caseReports.Save(caseReport);
         }
 
-        public async Task Process(InvalidReportFromUnknownDataCollectorReceived @event)
+        public void Process(InvalidReportFromUnknownDataCollectorReceived @event)
         {            
             var caseReport = new CaseReportForListing(@event.CaseReportId)
             {
@@ -96,7 +96,7 @@ namespace Read.CaseReportsForListing
                 Origin = @event.Origin,
                 ParsingErrorMessage = @event.ErrorMessages
             };
-            await _caseReports.Save(caseReport);
+            _caseReports.Save(caseReport);
         }
 
         //TODO: Remove error reports if they get fixed when we have events for that

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportStatus.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportStatus.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Read.CaseReportsForListing
 {

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportsForListing.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/CaseReportsForListing.cs
@@ -25,7 +25,7 @@ namespace Read.CaseReportsForListing
             return await list.ToListAsync();
         }
 
-        public async Task<IEnumerable<CaseReportForListing>> GetLimitAsync(int limit, Boolean last)
+        public async Task<IEnumerable<CaseReportForListing>> GetLimitAsync(int limit, bool last)
         {
             
             var filter = Builders<CaseReportForListing>.Filter.Empty;

--- a/Source/VolunteerReporting/Read/HealthRisks/HealthRisk.cs
+++ b/Source/VolunteerReporting/Read/HealthRisks/HealthRisk.cs
@@ -1,13 +1,11 @@
 using Concepts;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Read.HealthRisks
 {
     public class HealthRisk
     {
-        public HealthRiskId Id { get; set; }
+        public Guid Id { get; set; }
         public int ReadableId { get; set; }
         public string Name { get; set; }
 

--- a/Source/VolunteerReporting/Read/HealthRisks/HealthRiskEventProcessor.cs
+++ b/Source/VolunteerReporting/Read/HealthRisks/HealthRiskEventProcessor.cs
@@ -21,7 +21,6 @@ namespace Read.HealthRisks
                 Name = @event.Name
             };
             _healthRisks.Save(healthRisk);
-            var returned = _healthRisks.GetById(healthRisk.Id);
         }
     }
 }

--- a/Source/VolunteerReporting/Read/HealthRisks/HealthRiskEventProcessor.cs
+++ b/Source/VolunteerReporting/Read/HealthRisks/HealthRiskEventProcessor.cs
@@ -13,12 +13,15 @@ namespace Read.HealthRisks
             _healthRisks = healthRisks;
         }
 
-        public async Task Process(HealthRiskCreated @event)
+        public void Process(HealthRiskCreated @event)
         {
-            var healthRisk = _healthRisks.GetById(@event.Id) ?? new HealthRisk(@event.Id);
-            healthRisk.ReadableId = @event.ReadableId;
-            healthRisk.Name = @event.Name;
-            await _healthRisks.Save(healthRisk);
+            var healthRisk = new HealthRisk(@event.Id)
+            {
+                ReadableId = @event.ReadableId,
+                Name = @event.Name
+            };
+            _healthRisks.Save(healthRisk);
+            var returned = _healthRisks.GetById(healthRisk.Id);
         }
     }
 }

--- a/Source/VolunteerReporting/Read/HealthRisks/HealthRisks.cs
+++ b/Source/VolunteerReporting/Read/HealthRisks/HealthRisks.cs
@@ -40,15 +40,27 @@ namespace Read.HealthRisks
             return healthRiskId;
         }
 
-        public async Task Save(HealthRisk healthRisk)
+        public void Save(HealthRisk healthRisk)
+        {
+            var filter = Builders<HealthRisk>.Filter.Eq(c => c.Id, healthRisk.Id);
+            _collection.ReplaceOne(filter, healthRisk, new UpdateOptions { IsUpsert = true });
+        }
+
+        public void Remove(Guid healthRiskId)
+        {
+            var filter = Builders<HealthRisk>.Filter.Eq(c => c.Id, healthRiskId);
+            _collection.DeleteOne(filter);
+        }
+
+        public async Task SaveAsync(HealthRisk healthRisk)
         {
             var filter = Builders<HealthRisk>.Filter.Eq(c => c.Id, healthRisk.Id);
             await  _collection.ReplaceOneAsync(filter, healthRisk, new UpdateOptions { IsUpsert = true });
         }
 
-        public async Task Remove(Guid healthRiskId)
+        public async Task RemoveAsync(Guid healthRiskId)
         {
-            var filter = Builders<HealthRisk>.Filter.Eq(c => c.Id.Value, healthRiskId);
+            var filter = Builders<HealthRisk>.Filter.Eq(c => c.Id, healthRiskId);
             await _collection.DeleteOneAsync(filter);
         }
 

--- a/Source/VolunteerReporting/Read/HealthRisks/IHealthRisks.cs
+++ b/Source/VolunteerReporting/Read/HealthRisks/IHealthRisks.cs
@@ -11,8 +11,10 @@ namespace Read.HealthRisks
         HealthRisk GetById(Guid id);
         HealthRisk GetByReadableId(int readableId);
         HealthRiskId GetIdFromReadableId(int readbleId);
-        Task Save(HealthRisk dataCollector);
-        Task Remove(Guid healthRiskId);
+        void Save(HealthRisk dataCollector);
+        void Remove(Guid healthRiskId);
+        Task SaveAsync(HealthRisk dataCollector);
+        Task RemoveAsync(Guid healthRiskId);
         
     }
 }

--- a/Source/VolunteerReporting/Read/InvalidCaseReports/InvalidCaseReportEventProcessors.cs
+++ b/Source/VolunteerReporting/Read/InvalidCaseReports/InvalidCaseReportEventProcessors.cs
@@ -1,9 +1,5 @@
 using doLittle.Events.Processing;
-using doLittle.Time;
 using Events;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Read.InvalidCaseReports

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.html
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.html
@@ -40,6 +40,7 @@
             </td>
             <td>
                 <span *ngIf="caseReport.dataCollectorId">{{caseReport.dataCollectorDisplayName}}&nbsp;</span>
+                <span *ngIf="!caseReport.dataCollectorId">Origin:{{caseReport.origin}}&nbsp;</span>
             </td>
             <ng-container *ngIf="caseReport.healthRiskId">
                 <!-- <td>{{caseReport.healthRisk?.readableId}}: {{caseReport.healthRisk?.name}}</td> !-->
@@ -54,7 +55,7 @@
             </ng-container>
             <ng-container *ngIf="!caseReport.healthRiskId">
                 <td colspan="6">
-                    {{caseReport.message}}
+                    Received: {{caseReport.message}} Parsing errors: {{caseReport.parsingErrorMessage}}
                 </td>
             </ng-container>
         </tr>

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.html
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.html
@@ -55,7 +55,7 @@
             </ng-container>
             <ng-container *ngIf="!caseReport.healthRiskId">
                 <td colspan="6">
-                    Received: {{caseReport.message}} Parsing errors: {{caseReport.parsingErrorMessage}}
+                    {{caseReport.message}} Parsing errors: {{caseReport.parsingErrorMessage}}
                 </td>
             </ng-container>
         </tr>

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
@@ -65,6 +65,7 @@ export class CaseReportListComponent implements OnInit {
     this.caseReportService.getReports()
       .then(result => {
         this.listedReports = result || [];
+        console.log(this.listedReports);
       })
       .catch(error => console.error(error));
 

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
@@ -28,7 +28,6 @@ import {CaseReportExporter} from './exporter/case-report-exporter.service';
 export class CaseReportListComponent implements OnInit {
 
   listedReports: Array<CaseReportForListing>;
-  maxReports: number;
   filterField: string;
   filterValue: any;
 
@@ -39,13 +38,12 @@ export class CaseReportListComponent implements OnInit {
     'healthRiskId', 'healthRisk', 'message',
     'numberOfFemalesOver5', 'numberOfFemalesUnder5',
     'numberOfMalesOver5', 'numberOfMalesUnder5',
-    'timestamp', 'location'
+    'timestamp', 'location', 'origin', 'parsingErrorMessage'
   ];
 
   constructor(private caseReportService: AggregatedCaseReportService,
               private service: ReportService,
               private caseReportExporter: CaseReportExporter) {
-    this.maxReports = 10;
   }
 
   /**

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
@@ -65,7 +65,6 @@ export class CaseReportListComponent implements OnInit {
     this.caseReportService.getReports()
       .then(result => {
         this.listedReports = result || [];
-        console.log(this.listedReports);
       })
       .catch(error => console.error(error));
 

--- a/Source/VolunteerReporting/Web.Angular/src/app/core/aggregated-case-report.service.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/core/aggregated-case-report.service.ts
@@ -43,6 +43,7 @@ export class AggregatedCaseReportService {
     return this.http.get(`${environment.api}/api/casereports`, {headers: this.headers})
       .toPromise()
       .then(result => {
+        console.log(environment.api);
         return result.json();
       })
       .catch(error => console.error(error));

--- a/Source/VolunteerReporting/Web.Angular/src/app/core/aggregated-case-report.service.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/core/aggregated-case-report.service.ts
@@ -43,7 +43,6 @@ export class AggregatedCaseReportService {
     return this.http.get(`${environment.api}/api/casereports`, {headers: this.headers})
       .toPromise()
       .then(result => {
-        console.log(environment.api);
         return result.json();
       })
       .catch(error => console.error(error));

--- a/Source/VolunteerReporting/Web.Angular/src/app/shared/models/case-report-for-listing.model.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/shared/models/case-report-for-listing.model.ts
@@ -17,4 +17,7 @@ export class CaseReportForListing implements Report {
     numberOfMalesAges0To4: number;
     timestamp: Date;
     location: Location;AgedOver4;
+
+    origin: string;
+    parsingErrorMessage: Array<string>;
 }

--- a/Source/VolunteerReporting/Web.Angular/src/environments/environment.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/environments/environment.ts
@@ -5,5 +5,5 @@
 
 export const environment = {
   production: false,
-  api: 'http://dev.cbsrc.org/volunteerreportingbackend'
+  api: 'http://localhost:5000'
 };


### PR DESCRIPTION
This PR should resolve issues #595 and #596.

Had to do some work arounds in the Read, callin Synchronous methods instead of Async.

Important! When writing read models, mongodb will have issues when serializing/deserializing _id fields that are classes in the models (for example if we use a concept for the field in a model which represents its id field into the DB). Use Guid, that's atleast my temporal solution.

Had a pretty bad time solving this because of the thing mentioned above, so I changed some signatures in some of the Read-collections to be synchronous instead of Async. I'll just leave it as it is.

Another thing to mention is that when I had two EventProcessor classes listening for the same event, with async Task Process methods the results could vary, meaning that sometimes (or all the time in my case) only one of the EventProcessors catched the event... @einari 