### PR TITLE
Fix Auto-Sort and remove Refresh from Case Reports

### DIFF
--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.html
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.html
@@ -1,6 +1,5 @@
 <h3>
     Case Reports
-    <button (click)="refresh()">Refresh</button>
 </h3>
 
 <table class="table table-bordered table-striped">

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/case-report-list.component.ts
@@ -57,6 +57,7 @@ export class CaseReportListComponent implements OnInit {
      */
     getReports(criteria: ReportSearchCriteria) {
         this.lastCriteria = criteria;
+        if (this.listedReports === undefined) return;
         this.listedReports = this.service.getReports(this.listedReports, criteria);
     }
 
@@ -71,19 +72,12 @@ export class CaseReportListComponent implements OnInit {
     getAllReports() {
         this.caseReportService.getReports()
             .then(result => {
-                this.listedReports = result || [];
+                  this.listedReports = result || [];
+                  if (this.lastCriteria) {
+                    this.getReports(this.lastCriteria);
+                  }
             })
             .catch(error => console.error(error));
-
-    }
-
-    refresh() {
-        if( this.lastCriteria ) {
-            this.listedReports = this.service.getReports(this.listedReports, this.lastCriteria); 
-        } else {
-            this.getAllReports();
-        }
-        
     }
 
     onClick(name: string) {

--- a/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/sort/sortable-column.component.ts
+++ b/Source/VolunteerReporting/Web.Angular/src/app/case-report/case-report-list/sort/sortable-column.component.ts
@@ -36,6 +36,10 @@ export class SortableColumnComponent implements OnInit {
         this.sortDirection = '';
       }
     });
+    // if a sorting is set already, emit the event
+    if (this.sortDirection !== '') {
+      this.sortService.columnSorted({sortColumn: this.columnName, sortDirection: this.sortDirection});
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
The implementation of the refresh button didn't work (it didn't call the
backend to get new data), so it's gone. The refreshing can be done with
a normal browser refresh (which is more intuitive).

The auto-sort requested in #623 works now, but is maybe not the cleanest
way to do it. So maybe the person who built the sortable-table should
have a look and improve upon it.

Both the selected sorting and filters are lost when refreshing the page.
I think the best way to fix this is to use the Router to put those
things in the URL (really the only way to keep state).