### PR TITLE
Added quick links to front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ Want to know more? Visit our [website](https://src.cbsrc.org/).
 | Alert  | [![Build status](https://ci.appveyor.com/api/projects/status/2lab71gqtq8hkxn8/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-q2clx/branch/master) [![Test status](https://img.shields.io/appveyor/tests/karolikl/cbs-q2clx/master.svg)](https://ci.appveyor.com/project/karolikl/cbs-q2clx/branch/master/tests) |
 
 <!-- [![CircleCI](https://circleci.com/gh/sheeeng/cbs.png?style=shield&circle-token=df3dc5f6efbc2a267f7805f05a5e91d2878be9fd)](https://circleci.com/gh/sheeeng/cbs) | [![TravisCI Status](https://travis-ci.org/sheeeng/cbs.svg?branch=master)] -->
+
+## Quick links
+[Functional requirements](https://github.com/IFRCGo/cbs/blob/master/Documentation/Requirements/CBS%20Functional%20requirements%20and%20technology%20blueprint-2.pdf)


### PR DESCRIPTION
First link is to functional requirements. Other very important things should be easily available from the front page. Ex: trello board read url, realtime board read url


**Please check if the PR fulfills these requirements**

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #issuenumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.