### PR TITLE
Fix failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ services:
   - docker
 
 before_install:
-- docker pull dranoel/cbs-devel
+- docker pull redcrossredcrescent/cbs-cake-build:latest
 
 script:
 # - ls -al ${PWD}
-- docker run --rm --workdir=/workspace --volume ${PWD}:/workspace dranoel/cbs-devel:latest ./build.sh
+- docker run --rm --workdir=/workspace --volume ${PWD}:/workspace redcrossredcrescent/cbs-cake-build:latest ./build.sh

--- a/Build/tools/packages.config
+++ b/Build/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.23.0" />
+    <package id="Cake" version="0.28.0" />
 </packages>

--- a/Build/travis_cake_image/Dockerfile
+++ b/Build/travis_cake_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2-sdk-jessie
+FROM microsoft/dotnet:2.2-sdk-stretch
 
 # Install Mono
 
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 
-RUN echo "deb http://download.mono-project.com/repo/debian jessie main" \
+RUN echo "deb http://download.mono-project.com/repo/debian stretch main" \
   | tee /etc/apt/sources.list.d/mono-official.list
 
 RUN DEBIAN_FRONTEND=noninteractive \
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     locales
 
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -	
-RUN curl https://packages.microsoft.com/config/debian/8/prod.list | tee /etc/apt/sources.list.d/microsoft.list
+RUN curl https://packages.microsoft.com/config/debian/9/prod.list | tee /etc/apt/sources.list.d/microsoft.list
 
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get update \


### PR DESCRIPTION
The Travis builds seems to have failed because of an old .NET sdk base image, and an old Cake version.

I have built a new image to use for Travis, and moved it to the redcrossredcrescent Docker Hub organization. If this works, and the PR is merged, I will set up automated builds for this image as well.