### PR TITLE
Fixed aspnetcore runtime image for backends

### DIFF
--- a/Source/Admin/Web/Dockerfile
+++ b/Source/Admin/Web/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore --no-cache
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0.9
+FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
 WORKDIR /app
 COPY --from=dotnet-build /src/Source/Admin/Web/out .
 ENTRYPOINT ["dotnet", "Web.dll"]

--- a/Source/UserManagement/Web/Dockerfile
+++ b/Source/UserManagement/Web/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore --no-cache
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0.9
+FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
 WORKDIR /app
 COPY --from=dotnet-build /src/Source/UserManagement/Web/out .
 ENTRYPOINT ["dotnet", "Web.dll"]

--- a/Source/VolunteerReporting/Web/Dockerfile
+++ b/Source/VolunteerReporting/Web/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore --no-cache
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM microsoft/aspnetcore:2.0.9
+FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
 WORKDIR /app
 COPY --from=dotnet-build /src/Source/VolunteerReporting/Web/out .
 ENTRYPOINT ["dotnet", "Web.dll"]


### PR DESCRIPTION
The Docker images was building correctly, but failed to start. This
fixes that.