### PR TITLE
Removed build status from AppVeyor

### DIFF
--- a/Source/VolunteerReporting/readme.md
+++ b/Source/VolunteerReporting/readme.md
@@ -1,7 +1,7 @@
 # Volunteer Reporting
 
 ## Build status
-[![Build status](https://ci.appveyor.com/api/projects/status/tt50700nylx40eml/branch/master?svg=true)](https://ci.appveyor.com/project/karolikl/cbs-g81xy/branch/master)
+Todo: Get Azure DevOps build status
 
 ## Prerequisites
 


### PR DESCRIPTION
As we're moving to Azure Devops pipelines, I'm removing the build status from AppVeyor and checking whether it will trigger a build.

