### PR TITLE
Set data verifier for Data Collector upon creation

### DIFF
--- a/Source/UserManagement/Concepts/DataVerifier/DataVerifierId.cs
+++ b/Source/UserManagement/Concepts/DataVerifier/DataVerifierId.cs
@@ -1,0 +1,13 @@
+using System;
+using Dolittle.Concepts;
+
+namespace Concepts.DataVerifier
+{
+    public class DataVerifierId : ConceptAs<Guid>
+    {
+        public static implicit operator DataVerifierId(Guid value)
+        {
+            return new DataVerifierId { Value = value };
+        }
+    }
+}

--- a/Source/UserManagement/Concepts/DataVerifier/DataVerifierIdValidator.cs
+++ b/Source/UserManagement/Concepts/DataVerifier/DataVerifierIdValidator.cs
@@ -1,0 +1,14 @@
+using Dolittle.Validation;
+using FluentValidation;
+
+namespace Concepts.DataVerifier
+{
+    public class DataVerifierIdValidator : InputValidator<DataVerifierId>
+    {
+        public DataVerifierIdValidator()
+        {
+            RuleFor(id => id.Value)
+                .NotEmpty().WithMessage("Data Verifier Id cannot be empty");
+        }
+    }
+}

--- a/Source/UserManagement/Domain/DataCollector/Changing/ChangeLocation.cs
+++ b/Source/UserManagement/Domain/DataCollector/Changing/ChangeLocation.cs
@@ -1,4 +1,3 @@
-using System;
 using Concepts;
 using Concepts.DataCollector;
 using Dolittle.Commands;

--- a/Source/UserManagement/Domain/DataCollector/DataCollector.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataCollector.cs
@@ -45,7 +45,6 @@ namespace Domain.DataCollector
                 registeredAt,
                 region,
                 district
-                
             ));
 
             foreach (var phoneNumber in phoneNumbers)

--- a/Source/UserManagement/Domain/DataCollector/DataCollector.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataCollector.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Concepts;
+using Concepts.DataVerifier;
 using Dolittle.Domain;
-using Domain.DataCollector.Changing;
 using Domain.DataCollector.Registering;
 using Events.DataCollector;
 
@@ -24,7 +23,8 @@ namespace Domain.DataCollector
             string fullName, string displayName,
             int yearOfBirth, Sex sex, Language preferredLanguage,
             Location gpsLocation, IEnumerable<string> phoneNumbers, DateTimeOffset registeredAt,
-            string region, string district
+            string region, string district,
+            DataVerifierId dataVerifierId
             )
         {
             if (_isRegistered)
@@ -52,6 +52,8 @@ namespace Domain.DataCollector
             {
                 AddPhoneNumber(phoneNumber);
             }
+
+            ChangeDataVerifier(dataVerifierId);
         }
 
         public void ChangeLocation(Location location)
@@ -114,6 +116,14 @@ namespace Domain.DataCollector
 
         }
 
+        public void ChangeDataVerifier(DataVerifierId dataVerifierId)
+        {
+            Apply(new DataCollectorDataVerifierChanged(
+                EventSourceId,
+                dataVerifierId
+            ));
+        }
+
         #endregion
 
         #region On-methods
@@ -134,8 +144,6 @@ namespace Domain.DataCollector
         }
 
         #endregion
-
-        
     }
 }
 

--- a/Source/UserManagement/Domain/DataCollector/DataCollector.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataCollector.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Concepts;
-using Concepts.DataVerifier;
 using Dolittle.Domain;
 using Domain.DataCollector.Registering;
 using Events.DataCollector;
@@ -24,7 +23,7 @@ namespace Domain.DataCollector
             int yearOfBirth, Sex sex, Language preferredLanguage,
             Location gpsLocation, IEnumerable<string> phoneNumbers, DateTimeOffset registeredAt,
             string region, string district,
-            DataVerifierId dataVerifierId
+            Guid dataVerifierId
             )
         {
             if (_isRegistered)
@@ -115,7 +114,7 @@ namespace Domain.DataCollector
 
         }
 
-        public void ChangeDataVerifier(DataVerifierId dataVerifierId)
+        public void ChangeDataVerifier(Guid dataVerifierId)
         {
             Apply(new DataCollectorDataVerifierChanged(
                 EventSourceId,

--- a/Source/UserManagement/Domain/DataCollector/DataCollectorCommandHandler.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataCollectorCommandHandler.cs
@@ -37,7 +37,8 @@ namespace Domain.DataCollector
                 command.PhoneNumbers,
                 DateTimeOffset.UtcNow,
                 command.Region,
-                command.District
+                command.District,
+                command.DataVerifierId
                 );
         }
 

--- a/Source/UserManagement/Domain/DataCollector/DataCollectorCommandHandler.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataCollectorCommandHandler.cs
@@ -7,6 +7,7 @@ using System;
 using Dolittle.Domain;
 using Dolittle.Commands.Handling;
 using Domain.DataCollector.Changing;
+using Domain.DataCollector.DataVerifier;
 using Domain.DataCollector.Registering;
 using Domain.DataCollector.PhoneNumber;
 
@@ -89,5 +90,10 @@ namespace Domain.DataCollector
             root.RemovePhoneNumbers(command.PhoneNumber);
         }
 
+        public void Handle(ChangeDataVerifier command)
+        {
+            var root = _repository.Get(command.DataCollectorId.Value);
+            root.ChangeDataVerifier(command.DataVerifierId);
+        }
     }
 }

--- a/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifier.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifier.cs
@@ -1,0 +1,12 @@
+using Concepts.DataCollector;
+using Concepts.DataVerifier;
+using Dolittle.Commands;
+
+namespace Domain.DataCollector.DataVerifier
+{
+    public class ChangeDataVerifier : ICommand
+    {
+        public DataCollectorId DataCollectorId { get; set; }
+        public DataVerifierId DataVerifierId { get; set; }
+    }
+}

--- a/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifier.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifier.cs
@@ -1,5 +1,5 @@
+using System;
 using Concepts.DataCollector;
-using Concepts.DataVerifier;
 using Dolittle.Commands;
 
 namespace Domain.DataCollector.DataVerifier
@@ -7,6 +7,6 @@ namespace Domain.DataCollector.DataVerifier
     public class ChangeDataVerifier : ICommand
     {
         public DataCollectorId DataCollectorId { get; set; }
-        public DataVerifierId DataVerifierId { get; set; }
+        public Guid DataVerifierId { get; set; }
     }
 }

--- a/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifierValidator.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifierValidator.cs
@@ -1,0 +1,20 @@
+using Concepts.DataCollector;
+using Concepts.DataVerifier;
+using Dolittle.Commands.Validation;
+using FluentValidation;
+
+namespace Domain.DataCollector.DataVerifier
+{
+    public class ChangeDataVerifierValidator : CommandInputValidatorFor<ChangeDataVerifier>
+    {
+        public ChangeDataVerifierValidator()
+        {
+            RuleFor(_ => _.DataCollectorId)
+                .NotEmpty().WithMessage("Data Collector Id must be set")
+                .SetValidator(new DataCollectorIdValidator());
+            RuleFor(_ => _.DataVerifierId)
+                .NotEmpty().WithMessage("Data Verifier Id must be set")
+                .SetValidator(new DataVerifierIdValidator());
+        }
+    }
+}

--- a/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifierValidator.cs
+++ b/Source/UserManagement/Domain/DataCollector/DataVerifier/ChangeDataVerifierValidator.cs
@@ -12,9 +12,9 @@ namespace Domain.DataCollector.DataVerifier
             RuleFor(_ => _.DataCollectorId)
                 .NotEmpty().WithMessage("Data Collector Id must be set")
                 .SetValidator(new DataCollectorIdValidator());
-            RuleFor(_ => _.DataVerifierId)
-                .NotEmpty().WithMessage("Data Verifier Id must be set")
-                .SetValidator(new DataVerifierIdValidator());
+            //RuleFor(_ => _.DataVerifierId)
+            //    .NotEmpty().WithMessage("Data Verifier Id must be set")
+            //    .SetValidator(new DataVerifierIdValidator());
         }
     }
 }

--- a/Source/UserManagement/Domain/DataCollector/Registering/RegisterDataCollector.cs
+++ b/Source/UserManagement/Domain/DataCollector/Registering/RegisterDataCollector.cs
@@ -2,11 +2,11 @@
  *  Copyright (c) 2017 International Federation of Red Cross. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
- 
+
+using System;
 using System.Collections.Generic;
 using Concepts;
 using Concepts.DataCollector;
-using Concepts.DataVerifier;
 using Dolittle.Commands;
 
 namespace Domain.DataCollector.Registering
@@ -27,6 +27,6 @@ namespace Domain.DataCollector.Registering
         public string Region { get; set; }
         public string District { get; set; }
 
-        public DataVerifierId DataVerifierId { get; set; }
+        public Guid DataVerifierId { get; set; }
     }
 }

--- a/Source/UserManagement/Domain/DataCollector/Registering/RegisterDataCollector.cs
+++ b/Source/UserManagement/Domain/DataCollector/Registering/RegisterDataCollector.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using Concepts;
 using Concepts.DataCollector;
+using Concepts.DataVerifier;
 using Dolittle.Commands;
 
 namespace Domain.DataCollector.Registering
@@ -25,5 +26,7 @@ namespace Domain.DataCollector.Registering
 
         public string Region { get; set; }
         public string District { get; set; }
+
+        public DataVerifierId DataVerifierId { get; set; }
     }
 }

--- a/Source/UserManagement/Events/DataCollector/DataCollectorDataVerifierChanged.cs
+++ b/Source/UserManagement/Events/DataCollector/DataCollectorDataVerifierChanged.cs
@@ -1,0 +1,17 @@
+using System;
+using Dolittle.Events;
+
+namespace Events.DataCollector
+{
+    public class DataCollectorDataVerifierChanged : IEvent
+    {
+        public Guid DataCollectorId { get; }
+        public Guid DataVerifierId { get; }
+
+        public DataCollectorDataVerifierChanged(Guid dataCollectorId, Guid dataVerifierId)
+        {
+            DataCollectorId = dataCollectorId;
+            DataVerifierId = dataVerifierId;
+        }
+    }
+}

--- a/Source/UserManagement/Read/DataCollectors/DataCollector.cs
+++ b/Source/UserManagement/Read/DataCollectors/DataCollector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Concepts;
 using Concepts.DataCollector;
+using Concepts.DataVerifier;
 using Dolittle.ReadModels;
 using Infrastructure.Read.MongoDb;
 
@@ -24,12 +25,13 @@ namespace Read.DataCollectors
 
         public IEnumerable<PhoneNumber> PhoneNumbers { get; set; }
         public DateTimeOffset RegisteredAt { get; set; }
+        public DataVerifierId DataVerifier { get; set; }
 
         //TODO: Have this again when dolittle build tool supports nullables 
         //public DateTimeOffset? LastReportRecievedAt { get; set; }
 
         /// Comment from woksin 13.09-18: The dictionary might or might not work with dolittles platform as of now. 
-         public IDictionary<string, object> ExtraElements { get; set; } = new Dictionary<string, object>();
+        public IDictionary<string, object> ExtraElements { get; set; } = new Dictionary<string, object>();
 
     }
 }

--- a/Source/UserManagement/Read/DataCollectors/DataCollector.cs
+++ b/Source/UserManagement/Read/DataCollectors/DataCollector.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Concepts;
 using Concepts.DataCollector;
-using Concepts.DataVerifier;
 using Dolittle.ReadModels;
 using Infrastructure.Read.MongoDb;
 
@@ -25,7 +24,7 @@ namespace Read.DataCollectors
 
         public IEnumerable<PhoneNumber> PhoneNumbers { get; set; }
         public DateTimeOffset RegisteredAt { get; set; }
-        public DataVerifierId DataVerifier { get; set; }
+        public Guid DataVerifier { get; set; }
 
         //TODO: Have this again when dolittle build tool supports nullables 
         //public DateTimeOffset? LastReportRecievedAt { get; set; }

--- a/Source/UserManagement/Read/DataCollectors/DataCollectorEventProcessor.cs
+++ b/Source/UserManagement/Read/DataCollectors/DataCollectorEventProcessor.cs
@@ -1,15 +1,10 @@
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Threading.Tasks;
 using Concepts;
 using Concepts.DataCollector;
-using Concepts.DataVerifier;
 using Dolittle.Events.Processing;
 using Events.DataCollector;
 using Events.External;
 using MongoDB.Driver;
-using Read.DataVerifiers;
 
 namespace Read.DataCollectors
 {
@@ -111,7 +106,7 @@ namespace Read.DataCollectors
         public void Process(DataCollectorDataVerifierChanged @event)
         {
             _dataCollectors.Update(d => d.Id == (DataCollectorId)@event.DataCollectorId,
-                Builders<DataCollector>.Update.Set(d => d.DataVerifier, (DataVerifierId)@event.DataVerifierId));
+                Builders<DataCollector>.Update.Set(d => d.DataVerifier, @event.DataVerifierId));
         }
     }
 }

--- a/Source/UserManagement/Read/DataCollectors/DataCollectorEventProcessor.cs
+++ b/Source/UserManagement/Read/DataCollectors/DataCollectorEventProcessor.cs
@@ -4,10 +4,12 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Concepts;
 using Concepts.DataCollector;
+using Concepts.DataVerifier;
 using Dolittle.Events.Processing;
 using Events.DataCollector;
 using Events.External;
 using MongoDB.Driver;
+using Read.DataVerifiers;
 
 namespace Read.DataCollectors
 {
@@ -103,6 +105,13 @@ namespace Read.DataCollectors
             // TODO:
             // _dataCollectors.Update(d => d.Id == (DataCollectorId)@event.DataCollectorId,
             //     Builders<DataCollector>.Update.Set(d => d.LastReportRecievedAt, @event.Timestamp));
+        }
+
+        [EventProcessor("cfd0bcf3-e490-492d-b14c-f992fa9fd59b")]
+        public void Process(DataCollectorDataVerifierChanged @event)
+        {
+            _dataCollectors.Update(d => d.Id == (DataCollectorId)@event.DataCollectorId,
+                Builders<DataCollector>.Update.Set(d => d.DataVerifier, (DataVerifierId)@event.DataVerifierId));
         }
     }
 }

--- a/Source/UserManagement/Read/DataCollectors/DataCollectors.cs
+++ b/Source/UserManagement/Read/DataCollectors/DataCollectors.cs
@@ -1,22 +1,14 @@
 using MongoDB.Driver;
-using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Concepts;
 using Concepts.DataCollector;
 using Infrastructure.Read.MongoDb;
 
 namespace Read.DataCollectors
 {
-    public class DataCollectors : ExtendedReadModelRepositoryFor<DataCollector>,
-        IDataCollectors
+    public class DataCollectors : ExtendedReadModelRepositoryFor<DataCollector>, IDataCollectors
     {
-
-
-        public DataCollectors(IMongoDatabase database)
-            : base(database)
+        public DataCollectors(IMongoDatabase database) : base(database)
         {
-
         }
 
         public override IMongoCollection<DataCollector> GetCollection()
@@ -33,6 +25,5 @@ namespace Read.DataCollectors
         {
             return GetMany(_ => true);
         }
-
     }
 }

--- a/Source/UserManagement/Read/DataCollectors/IDataCollectors.cs
+++ b/Source/UserManagement/Read/DataCollectors/IDataCollectors.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Concepts;
 using Concepts.DataCollector;
 using Infrastructure.Read.MongoDb;
 
@@ -12,6 +9,5 @@ namespace Read.DataCollectors
         DataCollector GetById(DataCollectorId id);
 
         IEnumerable<DataCollector> GetAll();
-
     }
 }

--- a/Source/UserManagement/Read/DataVerifiers/DataVerifier.cs
+++ b/Source/UserManagement/Read/DataVerifiers/DataVerifier.cs
@@ -1,0 +1,11 @@
+using Concepts.DataVerifier;
+using Dolittle.ReadModels;
+
+namespace Read.DataVerifiers
+{
+    public class DataVerifier : IReadModel
+    {
+        public DataVerifierId Id { get; set; }
+        public string FullName { get; set; }
+    }
+}

--- a/Source/UserManagement/Read/DataVerifiers/DataVerifier.cs
+++ b/Source/UserManagement/Read/DataVerifiers/DataVerifier.cs
@@ -1,11 +1,11 @@
-using Concepts.DataVerifier;
+using System;
 using Dolittle.ReadModels;
 
 namespace Read.DataVerifiers
 {
     public class DataVerifier : IReadModel
     {
-        public DataVerifierId Id { get; set; }
+        public Guid Id { get; set; }
         public string FullName { get; set; }
     }
 }

--- a/Source/UserManagement/Read/DataVerifiers/DataVerifiers.cs
+++ b/Source/UserManagement/Read/DataVerifiers/DataVerifiers.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Infrastructure.Read.MongoDb;
+using MongoDB.Driver;
+
+namespace Read.DataVerifiers
+{
+    public class DataVerifiers : ExtendedReadModelRepositoryFor<DataVerifier>, IDataVerifiers
+    {
+        public DataVerifiers(IMongoDatabase database) : base(database)
+        {
+        }
+
+        public override IMongoCollection<DataVerifier> GetCollection()
+        {
+            return this._database.GetCollection<DataVerifier>("DataVerifiers");
+        }
+
+        public IEnumerable<DataVerifier> GetAll()
+        {
+            return GetMany(_ => true);
+        }
+    }
+}

--- a/Source/UserManagement/Read/DataVerifiers/IDataVerifiers.cs
+++ b/Source/UserManagement/Read/DataVerifiers/IDataVerifiers.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Read.DataVerifiers
+{
+    public interface IDataVerifiers
+    {
+        IEnumerable<DataVerifier> GetAll();
+    }
+}

--- a/Source/UserManagement/Web.Angular/src/app/user-detail/datacollector-detail.component.html
+++ b/Source/UserManagement/Web.Angular/src/app/user-detail/datacollector-detail.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="dataCollector">
     <h2>{{dataCollector.fullName}}</h2>
     <div><span>Display name: </span>{{dataCollector.displayName}}</div>
+    <div><span>Data verifier: </span>{{dataCollector.dataVerifierId}}</div>
     <div><span>Year of birth: </span>{{dataCollector.yearOfBirth}}</div>
     <div><span>Sex: </span><span>{{getSexString(dataCollector.sex)}}</span></div>
     <div><span>National society: </span>{{dataCollector.nationalSociety}}</div>

--- a/Source/UserManagement/Web.Angular/src/app/user-form/user-form-data-collector/user-form-data-collector.component.html
+++ b/Source/UserManagement/Web.Angular/src/app/user-form/user-form-data-collector/user-form-data-collector.component.html
@@ -40,7 +40,12 @@
       </div>
     </div>
   </div>
-
+  <div class="form-group">
+    <label for="data_verifier_id">Data verifier id</label>
+    <input type="text" class="form-control" id="data_verifier_id"
+            [(ngModel)]="command.dataVerifierId" name="data_verifier_id"
+            #data_verifier_id="ngModel">
+  </div>
   <div class="form-group">
     <label for="yearOfBirth">Year of Birth</label>
     <input type="number" class="form-control" id="yearOfBirth"

--- a/Source/UserManagement/Web/.dolittle/artifacts.json
+++ b/Source/UserManagement/Web/.dolittle/artifacts.json
@@ -48,6 +48,11 @@
           "artifact": "0a4fa57d-082b-4229-a508-d13e20376d31",
           "generation": 1,
           "type": "Events.DataCollector.PhoneNumberRemovedFromDataCollector, Events"
+        },
+        {
+          "artifact": "1ad2d504-f2f0-44ad-8215-2214dab13c2f",
+          "generation": 1,
+          "type": "Events.DataCollector.DataCollectorDataVerifierChanged, Events"
         }
       ],
       "eventSources": [
@@ -222,6 +227,32 @@
           "type": "Read.DataCollectors.Queries.DataCollectorById, Read"
         }
       ]
+    },
+    "16bfc05d-891c-4d00-8bd1-895aed754cea": {
+      "commands": [
+        {
+          "artifact": "284941ba-5be8-48b0-878b-ed85a339c5de",
+          "generation": 1,
+          "type": "Domain.DataCollector.DataVerifier.ChangeDataVerifier, Domain"
+        }
+      ],
+      "events": [],
+      "eventSources": [],
+      "readModels": [],
+      "queries": []
+    },
+    "bb94259d-c7df-4bd0-a44b-51c464939fab": {
+      "commands": [],
+      "events": [],
+      "eventSources": [],
+      "readModels": [
+        {
+          "artifact": "6335ea66-68c2-45b5-b6c5-2c447d88766e",
+          "generation": 1,
+          "type": "Read.DataVerifiers.DataVerifier, Read"
+        }
+      ],
+      "queries": []
     }
   }
 }

--- a/Source/UserManagement/Web/.dolittle/topology.json
+++ b/Source/UserManagement/Web/.dolittle/topology.json
@@ -24,6 +24,11 @@
           "feature": "ceb431f5-3173-44a8-aaeb-c7b8c73509eb",
           "name": "Changing",
           "subFeatures": []
+        },
+        {
+          "feature": "16bfc05d-891c-4d00-8bd1-895aed754cea",
+          "name": "DataVerifier",
+          "subFeatures": []
         }
       ]
     },
@@ -53,6 +58,11 @@
           "subFeatures": []
         }
       ]
+    },
+    {
+      "feature": "bb94259d-c7df-4bd0-a44b-51c464939fab",
+      "name": "DataVerifiers",
+      "subFeatures": []
     }
   ]
 }


### PR DESCRIPTION
Fixes the backend part of #644.

Because of the possible merge into volunteer reporting/react rewrite/proxy changes we haven't fixed the following:
- Listing all data verfiers in a dropdown list that you can choose from
- Set logged in user as the default data verifier
- Add this in the edit view