### PR TITLE
Change K8S ingress service to LoadBalancer so it's exposed publicly

### DIFF
--- a/Deploy/K8S/Infrastructure/ingress.yaml
+++ b/Deploy/K8S/Infrastructure/ingress.yaml
@@ -84,7 +84,8 @@ metadata:
 spec:
   selector:
     k8s-app: traefik-ingress-lb
+  type: LoadBalancer
   ports:
     - protocol: TCP
       port: 80
-      name: web
+      name: http


### PR DESCRIPTION
This is the configuration used in the dev cluster (which these files are meant for).