### PR TITLE
Sorted case reports from backend

### DIFF
--- a/Source/Navigation/Web.Common/package-lock.json
+++ b/Source/Navigation/Web.Common/package-lock.json
@@ -1695,9 +1695,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
-      "integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
+      "integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",

--- a/Source/Reporting/Read/Reporting/CaseReportsForListing/AllCaseReportsForListing.cs
+++ b/Source/Reporting/Read/Reporting/CaseReportsForListing/AllCaseReportsForListing.cs
@@ -26,14 +26,14 @@ namespace Read.Reporting.CaseReportsForListing
         {
             get
             {
-                // TODO implementd sortfield
-                var sortField = string.IsNullOrEmpty(SortField) ? nameof(CaseReportForListing.Timestamp) : SortField;
-                var query = _collection.Query.OrderBy(x=>x.Timestamp);//.OrderBy(SortAscending);
+                IQueryable<CaseReportForListing> query = _collection.Query;
+                if (string.IsNullOrWhiteSpace(SortField))
+                    query = SortAscending ? query.OrderBy(x => x.Timestamp) : query.OrderByDescending(x => x.Timestamp);
+                else
+                    query = query.OrderByFieldName(SortField, SortAscending);
 
-                if (PageSize > 0 && PageNumber >= 0)
-                {
-                    return query.Skip(PageSize * PageNumber).Take(PageSize);
-                }
+                if (PageSize > 0 && PageNumber >= 0) query = query.Skip(PageSize * PageNumber).Take(PageSize);
+
                 return query;
             }
         }

--- a/Source/Reporting/Read/Reporting/CaseReportsForListing/QueryExtensions.cs
+++ b/Source/Reporting/Read/Reporting/CaseReportsForListing/QueryExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Read.Reporting.CaseReportsForListing
+{
+    public static class QueryExtensions
+    {
+        public static IQueryable<T> OrderByFieldName<T>(this IQueryable<T> source, string fieldName, bool orderAscending)
+        {
+            if (string.IsNullOrWhiteSpace(fieldName))
+                return source;
+
+            var type = typeof(T);
+            var property = type.GetProperty(fieldName);
+            if (property == null)
+                return source;
+            var parameter = Expression.Parameter(type, "p");
+            var propertyAccess = Expression.MakeMemberAccess(parameter, property);
+            var orderByExp = Expression.Lambda(propertyAccess, parameter);
+            MethodCallExpression resultExp = Expression.Call(typeof(Queryable), orderAscending ? "OrderBy" : "OrderByDescending", new Type[] { type, property.PropertyType }, source.Expression, Expression.Quote(orderByExp));
+            return source.Provider.CreateQuery<T>(resultExp);
+        }
+    }
+}

--- a/Source/VolunteerReporting/Domain/Tests/Data/CaseReports.json
+++ b/Source/VolunteerReporting/Domain/Tests/Data/CaseReports.json
@@ -10,5 +10,17 @@
         "Longitude": 1,
         "Latitude": "1.",
         "Message": "Test messages"
+    },
+    {
+        "DataCollectorId": "e1638158-2017-42ae-a37c-e42acdb1c701",
+        "HealthRiskId": "39f7b018-50cc-4ab7-a8a8-d1047a42ee99",
+        "Origin": 1,
+        "NumberOfMalesUnder5": 3,
+        "NumberOfMalesAged5AndOlder": 3,
+        "NumberOfFemalesUnder5": 3,
+        "NumberOfFemalesAged5AndOlder": 3,
+        "Longitude": 1,
+        "Latitude": "1.",
+        "Message": "Test messages"
     }
 ]

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/AllCaseReportsForListing.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/AllCaseReportsForListing.cs
@@ -26,14 +26,14 @@ namespace Read.CaseReportsForListing
         {
             get
             {
-                // TODO implementd sortfield
-                var sortField = string.IsNullOrEmpty(SortField) ? nameof(CaseReportForListing.Timestamp) : SortField;
-                var query = _collection.Query.OrderBy(x=>x.Timestamp);//.OrderBy(SortAscending);
+                IQueryable<CaseReportForListing> query = _collection.Query;
+                if (string.IsNullOrWhiteSpace(SortField))
+                    query = SortAscending ? query.OrderBy(x => x.Timestamp) : query.OrderByDescending(x => x.Timestamp);
+                else
+                    query = query.OrderByFieldName(SortField, SortAscending);
 
-                if (PageSize > 0 && PageNumber >= 0)
-                {
-                    return query.Skip(PageSize * PageNumber).Take(PageSize);
-                }
+                if (PageSize > 0 && PageNumber >= 0) query = query.Skip(PageSize * PageNumber).Take(PageSize);
+
                 return query;
             }
         }

--- a/Source/VolunteerReporting/Read/CaseReportsForListing/QueryExtensions.cs
+++ b/Source/VolunteerReporting/Read/CaseReportsForListing/QueryExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Read.CaseReportsForListing
+{
+    public static class QueryExtensions
+    {
+        public static IQueryable<T> OrderByFieldName<T>(this IQueryable<T> source, string fieldName, bool orderAscending)
+        {
+            if (string.IsNullOrWhiteSpace(fieldName))
+                return source;
+
+            var type = typeof(T);
+            var property = type.GetProperty(fieldName);
+            if (property == null)
+                return source;
+            var parameter = Expression.Parameter(type, "p");
+            var propertyAccess = Expression.MakeMemberAccess(parameter, property);
+            var orderByExp = Expression.Lambda(propertyAccess, parameter);
+            MethodCallExpression resultExp = Expression.Call(typeof(Queryable), orderAscending ? "OrderBy" : "OrderByDescending", new Type[] { type, property.PropertyType }, source.Expression, Expression.Quote(orderByExp));
+            return source.Provider.CreateQuery<T>(resultExp);
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #910, implemented backend sorting on Case Reports.

Though this was implemented in both Volunteer Reporting and Reporting for some reason.
I will take upon myself to remove UserManagement and VolunteerReporting backends soon