### PR TITLE
Fix for multi-stage docker image creation  problem in azure devops

### DIFF
--- a/Source/Admin/Dockerfile
+++ b/Source/Admin/Dockerfile
@@ -34,9 +34,9 @@ RUN npm run ${mode}
 
 # Build runtime image
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
+COPY --from=build-web /CBS/Source/Admin/Web/dist /CBS/Core/wwwroot
 COPY ./Source/Admin/bounded-context.json /CBS/bounded-context.json
 COPY --from=build-core /CBS/Source/Admin/Core/out /CBS/Core/
 COPY --from=build-core /CBS/Source/Admin/Core/.dolittle /CBS/Core/.dolittle
-COPY --from=build-web /CBS/Source/Admin/Web/dist /CBS/Core/wwwroot
 WORKDIR /CBS/Core
 ENTRYPOINT ["dotnet", "/CBS/Core/Core.dll"]

--- a/Source/Alerts/Dockerfile
+++ b/Source/Alerts/Dockerfile
@@ -40,9 +40,9 @@ RUN yarn build
 
 # Build runtime image
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
+COPY --from=build-web /CBS/Source/Alerts/Web/dist /CBS/Core/wwwroot
 COPY --from=build-core /CBS/Source/Alerts/Core/out /CBS/Core/
 COPY --from=build-core /CBS/Source/Alerts/Core/.dolittle /CBS/Core/.dolittle
-COPY --from=build-web /CBS/Source/Alerts/Web/dist /CBS/Core/wwwroot
 COPY ./Source/Alerts/bounded-context.json /CBS/bounded-context.json
 WORKDIR /CBS/Core
 ENTRYPOINT ["dotnet", "/CBS/Core/Core.dll"]

--- a/Source/NotificationGateway/Dockerfile
+++ b/Source/NotificationGateway/Dockerfile
@@ -38,9 +38,9 @@ RUN yarn build
 
 # Build runtime image
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
+COPY --from=build-web /CBS/Source/NotificationGateway/Web/dist /CBS/Core/wwwroot
 COPY ./Source/NotificationGateway/bounded-context.json /CBS/bounded-context.json
 COPY --from=build-core /CBS/Source/NotificationGateway/Core/out /CBS/Core/
 COPY --from=build-core /CBS/Source/NotificationGateway/Core/.dolittle /CBS/Core/.dolittle
-COPY --from=build-web /CBS/Source/NotificationGateway/Web/dist /CBS/Core/wwwroot
 WORKDIR /CBS/Core
 ENTRYPOINT ["dotnet", "/CBS/Core/Core.dll"]

--- a/Source/Reporting/Dockerfile
+++ b/Source/Reporting/Dockerfile
@@ -41,9 +41,9 @@ RUN npm run ${mode}
 
 # Build runtime image
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
+COPY --from=build-web /CBS/Source/Reporting/Web/dist /CBS/Core/wwwroot
 COPY ./Source/Reporting/bounded-context.json /CBS/bounded-context.json
 COPY --from=build-core /CBS/Source/Reporting/Core/out /CBS/Core/
 COPY --from=build-core /CBS/Source/Reporting/Core/.dolittle /CBS/Core/.dolittle
-COPY --from=build-web /CBS/Source/Reporting/Web/dist /CBS/Core/wwwroot
 WORKDIR /CBS/Core
 ENTRYPOINT ["dotnet", "/CBS/Core/Core.dll"]

--- a/Source/Reporting/Dockerfile
+++ b/Source/Reporting/Dockerfile
@@ -34,12 +34,12 @@ COPY ./Source/Reporting/Web/package.json /CBS/Source/Reporting/Web/package.json
 WORKDIR /CBS/Source/Reporting/Web
 RUN yarn install
 
-# Build production code
+# Build frontend production code
 COPY ./Source/Reporting/Web /CBS/Source/Reporting/Web
 WORKDIR /CBS/Source/Reporting/Web
 RUN npm run ${mode}
 
-# Build runtime image
+# Build runtime image for the backend
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
 COPY --from=build-web /CBS/Source/Reporting/Web/dist /CBS/Core/wwwroot
 COPY ./Source/Reporting/bounded-context.json /CBS/bounded-context.json

--- a/Source/Reporting/Dockerfile
+++ b/Source/Reporting/Dockerfile
@@ -20,7 +20,7 @@ COPY ./Source/Reporting/Rules.Specs/Rules.Specs.csproj /CBS/Source/Reporting/Rul
 WORKDIR /CBS/Source/Reporting
 RUN dotnet restore
 
-# Build production code
+# Build backend production code
 COPY ./Source/Reporting /CBS/Source/Reporting
 WORKDIR /CBS/Source/Reporting/Core
 RUN dotnet publish --no-restore -c Release -o out


### PR DESCRIPTION
**Rearrange to run coping frontend before backend**

Coping the frontend Angular in multi-stage docker build is failing in Azure Pipeline. This is a fix by
rearranging the  execution steps in the reporting docker file to run coping frontend before backend.
The pipeline is setup to build and publish docker images to Azure Container Registry. 