### PR TITLE
the projects don't crash when app insights instrumentationkey not pre…

### DIFF
--- a/Source/Admin/Core/LoggingExtensions.cs
+++ b/Source/Admin/Core/LoggingExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
+
+namespace Core
+{
+    public static class LoggingExtensions
+    {
+        public static IWebHostBuilder ConfigureApplicationInsightsLogging(this IWebHostBuilder builder)
+        {
+            var instrumentationKey = Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY");
+
+            if (!String.IsNullOrEmpty(instrumentationKey))
+            {
+                builder.ConfigureLogging(_ => {
+                    _.AddApplicationInsights(instrumentationKey);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("Admin.Program", LogLevel.Trace);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("Admin.Startup", LogLevel.Trace);
+                });
+            }
+            
+            return builder;
+        }
+    }
+}

--- a/Source/Admin/Core/Program.cs
+++ b/Source/Admin/Core/Program.cs
@@ -21,13 +21,7 @@ namespace Core
         static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseKestrel()
-                .ConfigureLogging(builder => {
-                    builder.AddApplicationInsights(Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY"));
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("Admin.Program", LogLevel.Trace);
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("Admin.Startup", LogLevel.Trace);
-                })
+                .ConfigureApplicationInsightsLogging()
                 .ConfigureServices(services => services.AddAutofac())
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>();

--- a/Source/Alerts/Core/LoggingExtensions.cs
+++ b/Source/Alerts/Core/LoggingExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
+
+namespace Core
+{
+    public static class LoggingExtensions
+    {
+        public static IWebHostBuilder ConfigureApplicationInsightsLogging(this IWebHostBuilder builder)
+        {
+            var instrumentationKey = Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY");
+
+            if (!String.IsNullOrEmpty(instrumentationKey))
+            {
+                builder.ConfigureLogging(_ => {
+                    _.AddApplicationInsights(instrumentationKey);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("Alerts.Program", LogLevel.Trace);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("Alerts.Startup", LogLevel.Trace);
+                });
+            }
+            
+            return builder;
+        }
+    }
+}

--- a/Source/Alerts/Core/Program.cs
+++ b/Source/Alerts/Core/Program.cs
@@ -17,13 +17,7 @@ namespace Core
         static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseKestrel()
-                .ConfigureLogging(builder => {
-                    builder.AddApplicationInsights(Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY"));
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("Alerts.Program", LogLevel.Trace);
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("Alerts.Startup", LogLevel.Trace);
-                })
+                .ConfigureApplicationInsightsLogging()
                 .ConfigureServices(services => services.AddAutofac())
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>();

--- a/Source/NotificationGateway/Core/LoggingExtensions.cs
+++ b/Source/NotificationGateway/Core/LoggingExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
+
+namespace Core
+{
+    public static class LoggingExtensions
+    {
+        public static IWebHostBuilder ConfigureApplicationInsightsLogging(this IWebHostBuilder builder)
+        {
+            var instrumentationKey = Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY");
+
+            if (!String.IsNullOrEmpty(instrumentationKey))
+            {
+                builder.ConfigureLogging(_ => {
+                    _.AddApplicationInsights(instrumentationKey);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("NotificationGateway.Program", LogLevel.Trace);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("NotificationGateway.Startup", LogLevel.Trace);
+                });
+            }
+            
+            return builder;
+        }
+    }
+}

--- a/Source/NotificationGateway/Core/Program.cs
+++ b/Source/NotificationGateway/Core/Program.cs
@@ -18,13 +18,7 @@ namespace Core
         static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseKestrel()
-                .ConfigureLogging(builder => {
-                    builder.AddApplicationInsights(Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY"));
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("NotificationGateway.Program", LogLevel.Trace);
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("NotificationGateway.Startup", LogLevel.Trace);
-                })             
+                .ConfigureApplicationInsightsLogging()          
                 .ConfigureServices(services => services.AddAutofac())
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>();

--- a/Source/Reporting/Core/LoggingExtensions.cs
+++ b/Source/Reporting/Core/LoggingExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
+
+namespace Core
+{
+    public static class LoggingExtensions
+    {
+        public static IWebHostBuilder ConfigureApplicationInsightsLogging(this IWebHostBuilder builder)
+        {
+            var instrumentationKey = Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY");
+
+            if (!String.IsNullOrEmpty(instrumentationKey))
+            {
+                builder.ConfigureLogging(_ => {
+                    _.AddApplicationInsights(instrumentationKey);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("Reporting.Program", LogLevel.Trace);
+                    _.AddFilter<ApplicationInsightsLoggerProvider>("Reporting.Startup", LogLevel.Trace);
+                });
+            }
+            
+            return builder;
+        }
+    }
+}

--- a/Source/Reporting/Core/Program.cs
+++ b/Source/Reporting/Core/Program.cs
@@ -17,13 +17,7 @@ namespace Core
         static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseKestrel()
-                .ConfigureLogging(builder => {
-                    builder.AddApplicationInsights(Environment.GetEnvironmentVariable("ASPNETCORE_APPINSIGHTS_INSTRUMENTATIONKEY"));
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("Reporting.Program", LogLevel.Trace);
-                    builder.AddFilter<Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider>
-                                    ("Reporting.Startup", LogLevel.Trace);
-                })
+                .ConfigureApplicationInsightsLogging()
                 .ConfigureServices(services => services.AddAutofac())
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>();


### PR DESCRIPTION
Now checking if the environment variable is present before initializing application insights to prevent crashing.