### PR TITLE
copy bounded-context.json before build core

### DIFF
--- a/Source/Alerts/Dockerfile
+++ b/Source/Alerts/Dockerfile
@@ -41,8 +41,8 @@ RUN yarn build
 # Build runtime image
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-bionic
 COPY --from=build-web /CBS/Source/Alerts/Web/dist /CBS/Core/wwwroot
+COPY ./Source/Alerts/bounded-context.json /CBS/bounded-context.json
 COPY --from=build-core /CBS/Source/Alerts/Core/out /CBS/Core/
 COPY --from=build-core /CBS/Source/Alerts/Core/.dolittle /CBS/Core/.dolittle
-COPY ./Source/Alerts/bounded-context.json /CBS/bounded-context.json
 WORKDIR /CBS/Core
 ENTRYPOINT ["dotnet", "/CBS/Core/Core.dll"]


### PR DESCRIPTION
Build is crashing in devops pipeline when copying bounded-context.json after the build-core files