### PR TITLE
Set environment variable base url for alerts

### DIFF
--- a/Source/Alerts/Web/Environments/local_api.env
+++ b/Source/Alerts/Web/Environments/local_api.env
@@ -1,2 +1,2 @@
-API_BASE_URL=/
+API_BASE_URL=http://localhost:5000
 MOCK_COORDINATORS=false


### PR DESCRIPTION
Set the variable so that running alerts frontend against the backend on localhost works