### PR TITLE
Add reports to open alerts and remove them from available reports

### DIFF
--- a/Source/Alerts/Concepts/Alerts/AlertId.cs
+++ b/Source/Alerts/Concepts/Alerts/AlertId.cs
@@ -1,0 +1,21 @@
+using Dolittle.Concepts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Concepts.Alerts
+{
+    public class AlertId : ConceptAs<Guid>
+    {
+        public static readonly AlertId Empty = Guid.Empty;
+
+        public static implicit operator AlertId(Guid value)
+        {
+            return new AlertId { Value = value };
+        }
+        public static implicit operator AlertId(string value)
+        {
+            return new AlertId { Value = Guid.Parse(value) };
+        }
+    }
+}

--- a/Source/Alerts/Concepts/Report/ReportId.cs
+++ b/Source/Alerts/Concepts/Report/ReportId.cs
@@ -1,0 +1,21 @@
+using Dolittle.Concepts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Concepts.Report
+{
+    public class ReportId : ConceptAs<Guid>
+    {
+        public static readonly ReportId Empty = Guid.Empty;
+
+        public static implicit operator ReportId(Guid value)
+        {
+            return new ReportId { Value = value };
+        }
+        public static implicit operator ReportId(string value)
+        {
+            return new ReportId { Value = Guid.Parse(value) };
+        }
+    }
+}

--- a/Source/Alerts/Core/.dolittle/artifacts.json
+++ b/Source/Alerts/Core/.dolittle/artifacts.json
@@ -177,6 +177,10 @@
       "0c6aadaa-e2a3-474d-a630-8a2b2bca2f19": {
         "generation": 1,
         "type": "Events.Alerts.AlertOpened, Events"
+      },
+      "3589246b-e858-4082-b23f-2847859b5bed": {
+        "generation": 1,
+        "type": "Events.Alerts.ReportAddedToAlert, Events"
       }
     },
     "eventSources": {
@@ -230,5 +234,29 @@
         "type": "Read.DataCollectors.DataCollectorById, Read"
       }
     }
+  },
+  "1f0f878b-a603-4e40-b72e-d02cc25c162c": {
+    "commands": {},
+    "events": {},
+    "eventSources": {},
+    "readModels": {
+      "95669302-2eeb-4817-918b-4e6e1ea434bb": {
+        "generation": 1,
+        "type": "Read.Alerts.Open.OpenAlert, Read"
+      }
+    },
+    "queries": {}
+  },
+  "c2222e81-43db-4184-b0dd-296de083c97c": {
+    "commands": {},
+    "events": {},
+    "eventSources": {},
+    "readModels": {
+      "047f8af1-10a6-4964-bd34-6853a21cd852": {
+        "generation": 1,
+        "type": "Read.Reports.AvailableForRules.AvailableReport, Read"
+      }
+    },
+    "queries": {}
   }
 }

--- a/Source/Alerts/Core/.dolittle/topology.json
+++ b/Source/Alerts/Core/.dolittle/topology.json
@@ -3,7 +3,12 @@
   "features": {
     "fa2dc64d-8d1c-4910-ab62-43a5473c39ac": {
       "name": "Reports",
-      "subFeatures": {}
+      "subFeatures": {
+        "c2222e81-43db-4184-b0dd-296de083c97c": {
+          "name": "AvailableForRules",
+          "subFeatures": {}
+        }
+      }
     },
     "d2f10faf-7f8e-424a-bbc4-2e74f5ce3bac": {
       "name": "DataOwners",
@@ -11,7 +16,12 @@
     },
     "c2778e6d-ba03-4e8e-9d5d-dce46b34eed9": {
       "name": "Alerts",
-      "subFeatures": {}
+      "subFeatures": {
+        "1f0f878b-a603-4e40-b72e-d02cc25c162c": {
+          "name": "Open",
+          "subFeatures": {}
+        }
+      }
     },
     "60f798cf-54c4-48b5-bf04-c535c805d419": {
       "name": "AlertRules",

--- a/Source/Alerts/Domain/Alerts/Alerts.cs
+++ b/Source/Alerts/Domain/Alerts/Alerts.cs
@@ -22,6 +22,11 @@ namespace Domain.Alerts
             Apply(new AlertOpened(alertId, alertRuleId, numberOfAlertsOpened+1, cases.ToArray()));
         }
 
+        public void AddReportToAlert(Guid reportId, Guid alertId)
+        {
+            Apply(new ReportAddedToAlert(reportId, alertId));
+        }
+
         private void On(AlertOpened @event)
         {
             numberOfAlertsOpened++;

--- a/Source/Alerts/Events/Alerts/ReportAddedToAlert.cs
+++ b/Source/Alerts/Events/Alerts/ReportAddedToAlert.cs
@@ -1,0 +1,18 @@
+using Dolittle.Events;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Events.Alerts
+{
+    public class ReportAddedToAlert : IEvent
+    {
+        public ReportAddedToAlert(Guid reportId, Guid alertId)
+        {
+            ReportId = reportId;
+            AlertId = alertId;
+        }
+        public Guid ReportId { get; }
+        public Guid AlertId { get; }
+    }
+}

--- a/Source/Alerts/Read/Alerts/Open/EventProcessor.cs
+++ b/Source/Alerts/Read/Alerts/Open/EventProcessor.cs
@@ -1,0 +1,35 @@
+using Dolittle.Events.Processing;
+using Dolittle.ReadModels;
+using Events.Alerts;
+using Read.AlertRules;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Read.Alerts.Open
+{
+    public class EventProcessor : ICanProcessEvents
+    {
+        private readonly IReadModelRepositoryFor<OpenAlert> _items;
+        private readonly IReadModelRepositoryFor<AlertRule> _rules;
+
+        public EventProcessor(IReadModelRepositoryFor<OpenAlert> items, IReadModelRepositoryFor<AlertRule> rules)
+        {
+            _items = items;
+            _rules = rules;
+        }
+
+        [EventProcessor("811df61b-d2c2-4cef-add1-ea3fa1ee3c86")]
+        public void Process(AlertOpened @event)
+        {
+            var rule = _rules.GetById(@event.AlertRuleId);
+            var item = new OpenAlert
+            {
+                Id = rule.HealthRiskId,
+                AlertNumber = @event.AlertNumber,
+                AlertId = @event.AlertId
+            };
+            _items.Insert(item);
+        }
+    }
+}

--- a/Source/Alerts/Read/Alerts/Open/OpenAlert.cs
+++ b/Source/Alerts/Read/Alerts/Open/OpenAlert.cs
@@ -1,0 +1,16 @@
+using Concepts.Alerts;
+using Concepts.HealthRisks;
+using Dolittle.ReadModels;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Read.Alerts.Open
+{
+    public class OpenAlert : IReadModel
+    {
+        public HealthRiskNumber Id { get; set; }
+        public AlertId AlertId { get; set; }
+        public AlertNumber AlertNumber { get; set; }               
+    }
+}

--- a/Source/Alerts/Read/Reports/AvailableForRules/AvailableReport.cs
+++ b/Source/Alerts/Read/Reports/AvailableForRules/AvailableReport.cs
@@ -1,0 +1,18 @@
+using Concepts.Report;
+using Dolittle.ReadModels;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Read.Reports.AvailableForRules
+{
+    public class AvailableReport : IReadModel
+    {
+        public ReportId Id { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+        public Guid HealthRiskId { get; set; }
+        public int HealthRiskNumber { get; set; }
+    }
+}

--- a/Source/Alerts/Read/Reports/AvailableForRules/EventProcessor.cs
+++ b/Source/Alerts/Read/Reports/AvailableForRules/EventProcessor.cs
@@ -1,0 +1,56 @@
+using Dolittle.Events.Processing;
+using Dolittle.ReadModels;
+using Events.Alerts;
+using Events.Reports;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Read.Reports.AvailableForRules
+{
+    class EventProcessor : ICanProcessEvents
+    {
+        private readonly IReadModelRepositoryFor<AvailableReport> _availableReports;
+
+        public EventProcessor(
+            IReadModelRepositoryFor<AvailableReport> availableReports
+        )
+        {
+            _availableReports = availableReports;
+        }
+
+        [EventProcessor("9ea44541-94c7-494c-8f84-2d90004f8ce2")]
+        public void Process(ReportRegistered @event)
+        {
+            var item = new AvailableReport
+            {
+                Id = @event.ReportId,                
+                HealthRiskId = @event.HealthRiskId,
+                HealthRiskNumber = @event.HealthRiskNumber,
+                Latitude = @event.Latitude,
+                Longitude = @event.Longitude,
+                Timestamp = @event.Timestamp
+            };
+            _availableReports.Insert(item);
+        }
+
+        [EventProcessor("534c4f7c-a4dc-4bed-8202-a0bbab6d8fc7")]
+        public void Process(AlertOpened @event)
+        {
+            foreach(var reportId in @event.Reports)
+            {
+                var report = _availableReports.GetById(reportId);
+                if(report != null)
+                    _availableReports.Delete(report);
+            }            
+        }
+
+        [EventProcessor("f2e97576-e2a5-4104-bd11-2c1679f69db3")]
+        public void Process(ReportAddedToAlert @event)
+        {            
+            var report = _availableReports.GetById(@event.ReportId);
+            if(report != null)
+                _availableReports.Delete(report);            
+        }
+    }
+}

--- a/Source/Alerts/Web/Features/Alerts/Open/OpenAlert.js
+++ b/Source/Alerts/Web/Features/Alerts/Open/OpenAlert.js
@@ -1,0 +1,19 @@
+﻿/*---------------------------------------------------------------------------------------------
+ *  This file is an automatically generated ReadModel Proxy
+ *  
+ *--------------------------------------------------------------------------------------------*/
+import { ReadModel } from  '@dolittle/readmodels';
+
+export class OpenAlert extends ReadModel
+{
+    constructor() {
+        super();
+        this.artifact = {
+           id: '95669302-2eeb-4817-918b-4e6e1ea434bb',
+           generation: '1'
+        };
+        this.id = 0;
+        this.alertId = '00000000-0000-0000-0000-000000000000';
+        this.alertNumber = 0;
+    }
+}

--- a/Source/Alerts/Web/Features/Reports/AvailableForRules/AvailableReport.js
+++ b/Source/Alerts/Web/Features/Reports/AvailableForRules/AvailableReport.js
@@ -1,0 +1,22 @@
+﻿/*---------------------------------------------------------------------------------------------
+ *  This file is an automatically generated ReadModel Proxy
+ *  
+ *--------------------------------------------------------------------------------------------*/
+import { ReadModel } from  '@dolittle/readmodels';
+
+export class AvailableReport extends ReadModel
+{
+    constructor() {
+        super();
+        this.artifact = {
+           id: '047f8af1-10a6-4964-bd34-6853a21cd852',
+           generation: '1'
+        };
+        this.id = '00000000-0000-0000-0000-000000000000';
+        this.latitude = 0;
+        this.longitude = 0;
+        this.timestamp = new Date();
+        this.healthRiskId = '00000000-0000-0000-0000-000000000000';
+        this.healthRiskNumber = 0;
+    }
+}


### PR DESCRIPTION
If any alerts for a health risk is open, incomming reports will be added to this alert and will also be removed from the pool of available reports #959 #1138

The code has not been tested, but since Alert is not in use yet, it can be added. Hope to add some tests to this later, but created a pull reaquest now so the code can be checked and used if someone else wants to continue
