### PR TITLE
fixed hardcoded healthrisk name in casereportsforlisting

### DIFF
--- a/Deploy/Compose/config/analytics-event-horizons.json
+++ b/Deploy/Compose/config/analytics-event-horizons.json
@@ -13,7 +13,7 @@
     {
         "application": "fcb9885f-8b19-192e-be61-f966ee1c1640",
         "boundedContext": "64b3befc-2fb6-42f9-9e4b-bcb426fffffb",
-        "url": "cbs-admin:50052",
+        "url": "cbs-admin:50051",
         "events": [
             {
                 "id": "51b2c376-ce2b-4d49-a86c-e654e50248c9",

--- a/Source/Reporting/Read/Reporting/CaseReportsForListing/CaseReportForListingEventProcessor.cs
+++ b/Source/Reporting/Read/Reporting/CaseReportsForListing/CaseReportForListingEventProcessor.cs
@@ -47,8 +47,8 @@ namespace Read.Reporting.CaseReportsForListing
                 Location = dataCollector.Location,
                 Origin = @event.Origin,
 
-                HealthRiskId = @event.HealthRiskId,
-                HealthRisk = "Data currently not supporting finding healthRiskNames",
+                HealthRiskId = healthRisk.Id,
+                HealthRisk = healthRisk.Name,
 
                 NumberOfMalesUnder5 = @event.NumberOfMalesUnder5,
                 NumberOfMalesAged5AndOlder = @event.NumberOfMalesAged5AndOlder,


### PR DESCRIPTION
This reverts back to setting healthRiskName in CaseReportsForListing event processor