### PR TITLE
Last week totals (age & sex)

### DIFF
--- a/Source/Analytics/Web/src/components/CountryOverview/CountryOverview.js
+++ b/Source/Analytics/Web/src/components/CountryOverview/CountryOverview.js
@@ -8,6 +8,7 @@ import OverviewTop from '../OverviewTop/OverviewTop.js';
 import Map from "../Map.js";
 import CBSNavigation from '../Navigation/CBSNavigation';
 import HealthRiskSelector from "../healthRisk/HealthRiskSelector";
+import LastWeekTotals from "../lastWeekTotals/LastWeekTotals";
 
 const appInsights = new ApplicationInsights({
     config: {
@@ -44,6 +45,7 @@ class CountryOverview extends Component {
                     <HealthRiskPerDistrictTable />
                     <CaseReportByHealthRiskTable />
                     <Map />
+                    <LastWeekTotals />
                     <HealthRiskSelector />
                 </div>
             </>

--- a/Source/Analytics/Web/src/components/CountryOverview/CountryOverview.js
+++ b/Source/Analytics/Web/src/components/CountryOverview/CountryOverview.js
@@ -45,7 +45,11 @@ class CountryOverview extends Component {
                     <HealthRiskPerDistrictTable />
                     <CaseReportByHealthRiskTable />
                     <Map />
-                    <LastWeekTotals />
+                    <Grid container spacing={0}>
+                        <Grid item xs={12} sm={6} md={4}>
+                            <LastWeekTotals />
+                        </Grid>
+                    </Grid>
                     <HealthRiskSelector />
                 </div>
             </>

--- a/Source/Analytics/Web/src/components/lastWeekTotals/LastWeekTotals.js
+++ b/Source/Analytics/Web/src/components/lastWeekTotals/LastWeekTotals.js
@@ -68,7 +68,7 @@ export default class LastWeekTotals extends Component {
                             <TableCell className="headerText">Age</TableCell>
                             <TableCell className="headerText center"> <i className="fa fa-venus"> </i> Female</TableCell>
                             <TableCell className="headerText center"> <i className="fa fa-mars"></i> Male</TableCell>
-                            <TableCell className="headerText">Total</TableCell>
+                            <TableCell className="headerText center">Total</TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>


### PR DESCRIPTION
Added the component for total reports per age and sex to the country overview.

Placed this outside of the health risk toggle as the data currently is not filterable by health risk. This should be added, but I think it's good to have this component there in the meantime.