### PR TITLE
using <a> instead of <Link> in routing to other BCs

### DIFF
--- a/Source/Analytics/Web/src/components/Navigation/CBSNavigation.js
+++ b/Source/Analytics/Web/src/components/Navigation/CBSNavigation.js
@@ -107,9 +107,9 @@ class CBSNavigation extends Component {
             </Link>
         }
 
-        return <Link to={`/${url}/`} className={`menu-item ${url == active ? `active` : ``}`}>
+        return <a href={`/${url}/`} className={`menu-item ${url == active ? `active` : ``}`}>
             {text}
-        </Link>
+        </a>
     }
 
     render() {


### PR DESCRIPTION
For some reason, ```<Link>``` only redirects within the react app. 