### PR TITLE
Hotfix data collecting repository initialization

### DIFF
--- a/Source/Reporting/Policies/Reporting/Notifications/NotificationProcessor.cs
+++ b/Source/Reporting/Policies/Reporting/Notifications/NotificationProcessor.cs
@@ -59,7 +59,7 @@ namespace Policies.Reporting.Notifications
 
             var caseReportId = Guid.NewGuid();
             var caseReporting = _caseReportingRepository.Get(caseReportId);
-            var dataCollecting = _dataCollectorRepository.Get(dataCollector.Id.Value);
+            var dataCollecting = unknownDataCollector ? null : _dataCollectorRepository.Get(dataCollector.Id.Value);
 
             if (!isTextMessageFormatValid && unknownDataCollector)
             {


### PR DESCRIPTION
This is a fix for when there is an unknown data collector and initialization of the data collector repository fails when receiving reports in reporting.

What I did is set the repository to null when the data collector is unknown. It works because the repository is only used when data collector is known, but it's not a robust or elegant solution so I'm open to improvements. 😅 