### PR TITLE
Analytics aggregation fix

### DIFF
--- a/Source/Analytics/Core/.dolittle/artifacts.json
+++ b/Source/Analytics/Core/.dolittle/artifacts.json
@@ -220,6 +220,14 @@
       "d55c4484-cf1c-4c66-92c7-0f953cb2344d": {
         "generation": 1,
         "type": "Events.Reporting.DataCollectors.LastActiveUpdated, Events.Reporting"
+      },
+      "a73348f5-45ab-4913-8a6f-5947b44d6944": {
+        "generation": 1,
+        "type": "Events.Reporting.DataCollectors.DataCollectorBeganTraining, Events.Reporting"
+      },
+      "950cef1b-5e9f-44e3-b410-67749573eda7": {
+        "generation": 1,
+        "type": "Events.Reporting.DataCollectors.DataCollectorCompletedTraining, Events.Reporting"
       }
     },
     "eventSources": {},

--- a/Source/Analytics/Read/CaseReports/CaseReportEventProcessor.cs
+++ b/Source/Analytics/Read/CaseReports/CaseReportEventProcessor.cs
@@ -160,8 +160,7 @@ namespace Read.CaseReports
                 {
                     if (reportsPerRegion.TryGetValue(region.Name, out int totalReports))
                     {
-                        totalReports += numberOfReports;
-                        reportsPerRegion[region.Name] = totalReports;
+                        reportsPerRegion[region.Name] = totalReports + numberOfReports;
                     }
                     else
                     {

--- a/Source/Analytics/Read/CaseReports/CaseReportEventProcessor.cs
+++ b/Source/Analytics/Read/CaseReports/CaseReportEventProcessor.cs
@@ -159,11 +159,13 @@ namespace Read.CaseReports
                     if (reportsPerRegion.TryGetValue(region.Name, out int totalReports))
                     {
                         totalReports += numberOfReports;
+                        reportsPerRegion[region.Name] = totalReports;
                     }
                     else
                     {
                         reportsPerRegion.Add(region.Name, numberOfReports);
                     }
+                    reportsPerHealthRisk.ReportsPerHealthRisk[healthRisk.Name] = reportsPerRegion;
                 }
                 else
                 {

--- a/Source/Analytics/Read/CaseReports/CaseReportsPerRegionLast4Weeks.cs
+++ b/Source/Analytics/Read/CaseReports/CaseReportsPerRegionLast4Weeks.cs
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 using Concepts;
+using Concepts.HealthRisks;
 using Dolittle.ReadModels;
 using System.Collections.Generic;
 
@@ -12,6 +13,6 @@ namespace Read.CaseReports
     public class CaseReportsPerRegionLast4Weeks : IReadModel
     {
         public Day Id { get; set; }
-        public IList<HealthRisksInRegionsLast4Weeks> HealthRisks { get; set; }
+        public Dictionary<HealthRiskName, HealthRisksInRegionsLast4Weeks> HealthRisks { get; set; }
     }
 }

--- a/Source/Analytics/Read/CaseReports/HealthRisksInRegionsLast4Weeks.cs
+++ b/Source/Analytics/Read/CaseReports/HealthRisksInRegionsLast4Weeks.cs
@@ -6,13 +6,12 @@
 using Dolittle.ReadModels;
 using System.Collections.Generic;
 using Concepts.HealthRisks;
+using Concepts;
 
 namespace Read.CaseReports
 {
     public class HealthRisksInRegionsLast4Weeks : IReadModel
     {
-        public HealthRiskId Id { get; set; }
-        public HealthRiskName HealthRiskName { get; set; }
-        public IList<RegionWithHealthRisk> Regions { get; set; }
+        public Dictionary<RegionName, RegionWithHealthRisk> Regions { get; set; }
     }
 }

--- a/Source/Analytics/Web/src/Features/CaseReports/HealthRisksInRegionsLast4Weeks.js
+++ b/Source/Analytics/Web/src/Features/CaseReports/HealthRisksInRegionsLast4Weeks.js
@@ -12,8 +12,6 @@ export class HealthRisksInRegionsLast4Weeks extends ReadModel
            id: '73617dac-5e93-48f6-a8d2-6320961a81fd',
            generation: '1'
         };
-        this.id = '00000000-0000-0000-0000-000000000000';
-        this.healthRiskName = '';
         this.regions = [];
     }
 }

--- a/Source/Analytics/Web/src/components/Reports/ReportsPerHealthRiskPerRegionLast4Weeks.js
+++ b/Source/Analytics/Web/src/components/Reports/ReportsPerHealthRiskPerRegionLast4Weeks.js
@@ -50,16 +50,18 @@ class ReportsPerHealthRiskPerRegionLast4Weeks extends Component {
         </TableCell>
     }
 
+    getTotalReports(region) {
+        return region.days0to6 + region.days14to20 + region.days21to27 + region.days7to13;
+    }
+
     renderRows() {
-        const currentHealthRisk = this.state.regionsForHealthRisk.find(r => r.healthRiskName == this.props.selectedHealthRisk);
+        const currentHealthRisk = this.state.regionsForHealthRisk[this.props.selectedHealthRisk];
 
         if (currentHealthRisk != null) {
-            return currentHealthRisk.regions.map(region => {
-                const totalReports = Object.values(region).reduce(function (acc, val) {
-                    if (!isNaN(val))
-                        return acc + val;
-                    return acc
-                }, 0);
+            const regions = Object.keys(currentHealthRisk.regions);
+            return regions.map(regionName => {
+                const region = currentHealthRisk.regions[regionName];
+                const totalReports = this.getTotalReports(region);
 
                 return (
                     <TableRow key={region.name}>

--- a/Source/Reporting/Core/.dolittle/artifacts.json
+++ b/Source/Reporting/Core/.dolittle/artifacts.json
@@ -199,6 +199,10 @@
       "08ba2dff-69fe-4053-87b6-7e9f3d7faf23": {
         "generation": 1,
         "type": "Events.Reporting.CaseReports.TrainingReportReceived, Events"
+      },
+      "048b5f0f-cc5b-4fda-a0db-aa83cebbc418": {
+        "generation": 1,
+        "type": "Events.Reporting.CaseReports.InvalidTrainingReportReceived, Events"
       }
     },
     "eventSources": {


### PR DESCRIPTION
I updated the data model for CaseReportsPerRegionLast4Weeks to make it easier to update and aggregate data correctly.

Currently both of the tables in analytics are not aggregated because the event processor is not updating an existing entry in the database. That means that each day/week in the table is consisting of a single report only.

I have made scripts to clean the data already in the database to relaunch analytics from scratch and make it work with correct data.

Fixes #1214 