### PR TITLE
cleaned up reporting modal imports

### DIFF
--- a/Source/Reporting/Web/src/app/app.module.ts
+++ b/Source/Reporting/Web/src/app/app.module.ts
@@ -12,9 +12,6 @@ import { AgmCoreModule } from '@agm/core';
 import { AppComponent } from './app.component';
 import { NavbarHostComponent } from './navigation/navbar-host.component';
 
-import { ModalModule } from 'ngx-bootstrap';
-import { NgxSmartModalModule } from 'ngx-smart-modal';
-
 import { CommandCoordinator } from '@dolittle/commands';
 import { QueryCoordinator } from '@dolittle/queries';
 
@@ -54,8 +51,6 @@ NavbarHostComponent.apiBaseUrl = environment.api;
     ReactiveFormsModule,
     FormsModule,
     BrowserAnimationsModule,
-    NgxSmartModalModule.forRoot(),
-    ModalModule.forRoot(),
     ToastrModule.forRoot(),
     RouterModule.forRoot(routes),
     DataCollectorsModule,

--- a/Source/Reporting/Web/src/app/shared/shared.module.ts
+++ b/Source/Reporting/Web/src/app/shared/shared.module.ts
@@ -12,8 +12,7 @@ import { AppInsightsService } from '../services/app-insights-service';
         FormsModule,
         ReactiveFormsModule,
         HttpClientModule,
-        AgmCoreModule,
-        NgxSmartModalModule
+        AgmCoreModule
     ],
     declarations: [],
     exports: [


### PR DESCRIPTION
The latest build of the reporting bounded context fails in runtime on the azure server with the error below. 

When run locally on my machine with the same docker image and configurations, it runs fine. I think the problem is something in the messy import structure of the modal module, so I have tried to clean it up a little.

I tested by building this docker image and pushing it to the dev environment and that worked.

![image](https://user-images.githubusercontent.com/14860062/65862736-2c8fb000-e36f-11e9-8843-2b6f816bf355.png)
