### PR TITLE
Link to nyss repository in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This repository is no longer actively maintained. The development of this turned into the CBS system [Nyss](https://cbs.ifrc.org/what-nyss). The Nyss repository can be found [here](https://github.com/nyss-platform-norcross/nyss).
+
 # Red Cross: Community Based Surveillance (CBS)
 
 Join the world’s largest humanitarian organisation and code for the greater good!


### PR DESCRIPTION
Since this repo is no longer actively maintained and was superceded by Nyss, we should archive it. Before archiving it, we want to link to the nyss repository in the readme.